### PR TITLE
Update github links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,7 +13,7 @@ contact_links:
     url: https://github.com/rescript-lang/rescript-react/issues
     about: ReScript bindings to React.js
   - name: 🌐 rescript-core
-    url: https://github.com/rescript-association/rescript-core/issues
+    url: https://github.com/rescript-lang/rescript-core/issues
     about: New ReScript standard library
   - name: 💬 ReScript Forum
     url: https://forum.rescript-lang.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Please make sure to check out our [Code of Conduct](CODE_OF_CONDUCT.md) and make
 
 ## Ways to contribute
 
-- Writing docs for the manual (Check for issues that are marked with a [`manual`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"manual") and [`help wanted`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") tag)
-- Joining in discussions on our [issue tracker](https://github.com/rescript-association/rescript-lang.org/issues)
+- Writing docs for the manual (Check for issues that are marked with a [`manual`](https://github.com/rescript-lang/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"manual") and [`help wanted`](https://github.com/rescript-lang/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") tag)
+- Joining in discussions on our [issue tracker](https://github.com/rescript-lang/rescript-lang.org/issues)
 - Give feedback for improvements (incomplete / missing docs, bad wording,
   search user experience / design, etc.)
 - Advanced: Help building platform features (design system, automatic testing, markdown parsing, etc.)
@@ -16,7 +16,7 @@ Please make sure to check out our [Code of Conduct](CODE_OF_CONDUCT.md) and make
 
 ### Find an issue
 
-Before you start any work or submit any PRs, make sure to check our [issue tracker](https://github.com/rescript-association/rescript-lang.org/issues) for any issues or discussions on the topic.
+Before you start any work or submit any PRs, make sure to check our [issue tracker](https://github.com/rescript-lang/rescript-lang.org/issues) for any issues or discussions on the topic.
 
 If you can't find any relevant issues, feel free to create a new one to start a discussion. We usually assign issues to a responsible person to prevent confusion and duplicate work, so always double check if an issue is currently being worked on, or talk to the current assignee to take over the task.
 
@@ -24,7 +24,7 @@ If you can't find any relevant issues, feel free to create a new one to start a 
 
 The project follows very specific goals and tries to deliver the highest value with the least amount of resources. Please help us focus on the tasks at hand and don't submit any code / bigger refactorings without any proper discussion on the issue tracker. Otherwise your PR might not be accepted!
 
-If you need inspiration on what to work on, you can check out issues tagged with [`good first issue`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") or [`help wanted`](https://github.com/rescript-association/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted").
+If you need inspiration on what to work on, you can check out issues tagged with [`good first issue`](https://github.com/rescript-lang/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") or [`help wanted`](https://github.com/rescript-lang/rescript-lang.org/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted").
 
 ### Discuss an issue
 
@@ -44,7 +44,7 @@ We value your voluntary work, and of course it's fine to step back from a ticket
 
 ### Communication Channels
 
-- [Issue Tracker](https://github.com/rescript-association/rescript-lang.org/issues)
+- [Issue Tracker](https://github.com/rescript-lang/rescript-lang.org/issues)
 - [ReScript Discourse (General / mostly unrelated discussions)](http://forum.rescript-lang.org)
 
 ## Working on the rescript-lang.org

--- a/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
+++ b/_blogposts/2020-11-17-editor-support-custom-operators-and-more.mdx
@@ -8,7 +8,7 @@ description: |
   Update on what we're doing around the end of 2020 and early next year.
 ---
 
-import Video from "src/components/Video"
+import Video from "src/components/Video";
 
 ## Upcoming Improvements
 
@@ -28,7 +28,7 @@ Hongbo continues to improve the compiler experience in monorepo-like setups. Exp
 
 ## Docs
 
-Patrick is [rearranging the React documentation](https://github.com/rescript-association/rescript-lang.org/pull/96), and continues to improve the main documentation site with Cheng Lou.
+Patrick is [rearranging the React documentation](https://github.com/rescript-lang/rescript-lang.org/pull/96), and continues to improve the main documentation site with Cheng Lou.
 
 ## Syntax
 

--- a/_blogposts/2021-03-03-rescript-association-rebranding.mdx
+++ b/_blogposts/2021-03-03-rescript-association-rebranding.mdx
@@ -25,7 +25,7 @@ Founded in 2018, the ReScript Association provides a legal and financial foundat
 - [rescript-lang.org](https://rescript-lang.org).
 - [Community forum](https://forum.rescript-lang.org) & server.
 - ReScript related domains and [analytics data](https://simpleanalytics.com/rescript-lang.org).
-- [genType’s](https://github.com/rescript-association/genType) release automation.
+- [genType’s](https://github.com/rescript-lang/genType) release automation.
 - Help maintaining editor related tools such as [rescript-vscode](https://github.com/rescript-lang/rescript-vscode), [vim-rescript](https://github.com/rescript-lang/vim-rescript) and the underlying [editor-support](https://github.com/rescript-lang/rescript-editor-support).
 - Design & logo assets (together with our designer) for all of ReScript.
 - Helping out on upcoming [ocaml.org](https://ocaml.org) work.
@@ -48,6 +48,7 @@ High quality, long-term Open Source work doesn’t come from some good words and
 If your company relies on the ReScript platform for building commercial products, please consider supporting our efforts by [sending a donation](https://rescript-association.org/donate). It’s the best way to future proof your product’s foundation. Alternatively, you can sponsor individual members like [ryyppy](https://github.com/sponsors/ryyppy/) on GitHub Sponsors.
 
 We want to take this opportunity to thank our previous and active sponsors:
+
 - [Tezos Foundation](https://tezos.foundation) (2020-21)
 - [Ahrefs](https://ahrefs.com) (2019)
 - [OCaml Software Foundation](https://ocaml-sf.org) (2018-19)

--- a/_blogposts/2021-06-25-roadmap-2021-and-new-landing-page.mdx
+++ b/_blogposts/2021-06-25-roadmap-2021-and-new-landing-page.mdx
@@ -21,7 +21,7 @@ It has almost been a year since we originally [launched our new ReScript brand](
 - Accessible object system (no need for `Js.t`)
 - The release of our new `rescript` npm package and cli to replace `bs-platform`
 - Making every part of ReScript fully community owned
-- etc. 
+- etc.
 
 Stay tuned, this is just the beginning!
 
@@ -30,6 +30,7 @@ Stay tuned, this is just the beginning!
 We had some thorough discussions about the future of the project and outlined the most important milestones for the next upcoming releases.
 
 **Here's the gist:**
+
 - Two release channels: `stable` and `experimental`
 - More predictable release dates and better migration steps
 - Better communication and discussion for breaking changes
@@ -41,7 +42,11 @@ The detailed roadmap with all our planned changes (and definition of our release
 
 After several iterations, we are happy to announce our new [landing page](/).
 
-<Image src="/static/img/landing_page_figma.png" withShadow={true} caption="Figma design draft for the new landing page"/>
+<Image
+  src="/static/img/landing_page_figma.png"
+  withShadow={true}
+  caption="Figma design draft for the new landing page"
+/>
 
 This is an incredible milestone for the documentation, and will act as a foundation for some cool new future improvements, such as:
 
@@ -49,7 +54,6 @@ This is an incredible milestone for the documentation, and will act as a foundat
 - An interactive playground widget for the headline code examples
 - New starter templates and guides
 
-
-Furthermore, in case you are a **production user of ReScript** and you want to see your company logo highlighted on the landing page, please [open an issue](https://github.com/rescript-association/rescript-lang.org/issues) and let us know!
+Furthermore, in case you are a **production user of ReScript** and you want to see your company logo highlighted on the landing page, please [open an issue](https://github.com/rescript-lang/rescript-lang.org/issues) and let us know!
 
 Happy hacking.

--- a/_blogposts/2023-02-02-release-10-1.mdx
+++ b/_blogposts/2023-02-02-release-10-1.mdx
@@ -303,6 +303,6 @@ As always, we want to thank our [contributors](https://github.com/rescript-lang/
 
 We hope you enjoy the newest improvements as much as we do.
 
-In case there's any issues / problems, make sure to report bugs to [rescript-lang/rescript-compiler](https://github.com/rescript-lang/rescript-compiler) (language / syntax / jsx), [rescript-lang/rescript-react](https://github.com/rescript-lang/rescript-react) (React 16 / 18 binding) or [rescript-association/rescript-lang.org](https://github.com/rescript-association/rescript-lang.org) (documentation) repositories.
+In case there's any issues / problems, make sure to report bugs to [rescript-lang/rescript-compiler](https://github.com/rescript-lang/rescript-compiler) (language / syntax / jsx), [rescript-lang/rescript-react](https://github.com/rescript-lang/rescript-react) (React 16 / 18 binding) or [rescript-association/rescript-lang.org](https://github.com/rescript-lang/rescript-lang.org) (documentation) repositories.
 
 Also feel free to visit the [ReScript forum](https://forum.rescript-lang.org/) to ask questions and connect with other ReScripters.

--- a/_blogposts/2023-04-17-improving-interop.mdx
+++ b/_blogposts/2023-04-17-improving-interop.mdx
@@ -198,7 +198,7 @@ let getBestFriendsAge = user =>
 As you can see, you need to convert each level of nullables explicitly, which makes it hard to fully utilize pattern matching. With the new unboxed variant representation, we'll instead be able to do this:
 
 ```rescript
-// The type definition below is inlined here to examplify, but this definition will live in [Core](https://github.com/rescript-association/rescript-core) and be easily accessible
+// The type definition below is inlined here to examplify, but this definition will live in [Core](https://github.com/rescript-lang/rescript-core) and be easily accessible
 module Null = {
   @unboxed type t<'a> = Present('a) | @as(null) Null
 }

--- a/_blogposts/2024-01-11-release-11-0-0.mdx
+++ b/_blogposts/2024-01-11-release-11-0-0.mdx
@@ -50,7 +50,7 @@ This release is also introducing uncurried mode, which is a new default mode tha
 
 ### New Standard Library: ReScript Core
 
-[ReScript Core](https://github.com/rescript-association/rescript-core) is ReScript's new standard library. It replaces the complete `Js` module as well as some of the more frequently used modules from `Belt` and is recommended to use with uncurried mode.
+[ReScript Core](https://github.com/rescript-lang/rescript-core) is ReScript's new standard library. It replaces the complete `Js` module as well as some of the more frequently used modules from `Belt` and is recommended to use with uncurried mode.
 
 The latest docs on [rescript-lang.org](/) already use it for the examples. Have a look at the new [RescriptCore API docs](/docs/manual/latest/api/core).
 
@@ -149,4 +149,4 @@ In case of issues / problems, make sure to report bugs to one of the following r
 - [rescript-lang/rescript-react](https://github.com/rescript-lang/rescript-react) (React bindings)
 - [rescript-lang/rescript-vscode](https://github.com/rescript-lang/rescript-vscode) (VSCode language support, LSP, tools)
 - [rescript-lang/create-rescript-app](https://github.com/rescript-lang/create-rescript-app) (project generator) or
-- [rescript-association/rescript-lang.org](https://github.com/rescript-association/rescript-lang.org) (documentation)
+- [rescript-association/rescript-lang.org](https://github.com/rescript-lang/rescript-lang.org) (documentation)

--- a/misc_docs/syntax/decorator_dead.mdx
+++ b/misc_docs/syntax/decorator_dead.mdx
@@ -6,10 +6,10 @@ summary: "This is the `@dead` decorator."
 category: "decorators"
 ---
 
-> This decorator requires [`reanalyze`](https://github.com/rescript-association/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-association/reanalyze).
+> This decorator requires [`reanalyze`](https://github.com/rescript-lang/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-lang/reanalyze).
 
 `@dead` is picked up by reanalyze's dead code analysis, and suppresses reporting on the value/type, but can also be used to force the analysis to consider a value as dead. Typically used to acknowledge cases of dead code you are not planning to address right now, but can be searched easily later.
 
 ### References
 
-- [Reanalyze: Controlling reports with Annotations](https://github.com/rescript-association/reanalyze#dce-controlling-reports-with-annotations)
+- [Reanalyze: Controlling reports with Annotations](https://github.com/rescript-lang/reanalyze#dce-controlling-reports-with-annotations)

--- a/misc_docs/syntax/decorator_does_not_raise.mdx
+++ b/misc_docs/syntax/decorator_does_not_raise.mdx
@@ -6,10 +6,10 @@ summary: "This is the `@doesNotRaise` decorator."
 category: "decorators"
 ---
 
-> This decorator requires [`reanalyze`](https://github.com/rescript-association/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-association/reanalyze).
+> This decorator requires [`reanalyze`](https://github.com/rescript-lang/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-lang/reanalyze).
 
 `@doesNotRaise` is used to override the reanalyze's exception analysis and state that an expression does not raise any exceptions, even though the analysis reports otherwise. This can happen for example in the case of array access where the analysis does not perform range checks but takes a conservative stance that any access could potentially raise.
 
 ### References
 
-- [Reanalyze: Exception Analysis](https://github.com/rescript-association/reanalyze/blob/master/EXCEPTION.md)
+- [Reanalyze: Exception Analysis](https://github.com/rescript-lang/reanalyze/blob/master/EXCEPTION.md)

--- a/misc_docs/syntax/decorator_live.mdx
+++ b/misc_docs/syntax/decorator_live.mdx
@@ -6,11 +6,11 @@ summary: "This is the `@live` decorator."
 category: "decorators"
 ---
 
-> This decorator requires [`reanalyze`](https://github.com/rescript-association/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-association/reanalyze).
+> This decorator requires [`reanalyze`](https://github.com/rescript-lang/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-lang/reanalyze).
 
 `@live` tells reanalyze's dead code analysis that the value should be considered live, even though it might appear to be dead. This is typically used in case of FFI where there are indirect ways to access values.
 It can be added to everything that could otherwise be considered unused by the dead code analysis - values, functions, arguments, records, individual record fields, and so on.
 
 ### References
 
-- [Reanalyze: Controlling reports with Annotations](https://github.com/rescript-association/reanalyze#dce-controlling-reports-with-annotations)
+- [Reanalyze: Controlling reports with Annotations](https://github.com/rescript-lang/reanalyze#dce-controlling-reports-with-annotations)

--- a/misc_docs/syntax/decorator_raises.mdx
+++ b/misc_docs/syntax/decorator_raises.mdx
@@ -6,10 +6,10 @@ summary: "This is the `@raises` decorator."
 category: "decorators"
 ---
 
-> This decorator requires [`reanalyze`](https://github.com/rescript-association/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-association/reanalyze).
+> This decorator requires [`reanalyze`](https://github.com/rescript-lang/reanalyze), a code analysis tool for ReScript, to be installed. [Click here to read about how you get started with reanalyze.](https://github.com/rescript-lang/reanalyze).
 
 `@raises` is picked up by reanalyze's exception analysis, and acknowledges that a function can raise exceptions that are not caught, and suppresses a warning in that case. Callers of the functions are then subjected to the same rule. Example `@raises(Exn)` or `@raises([E1, E2, E3])` for multiple exceptions.
 
 ### References
 
-- [Reanalyze: Exception Analysis](https://github.com/rescript-association/reanalyze/blob/master/EXCEPTION.md)
+- [Reanalyze: Exception Analysis](https://github.com/rescript-lang/reanalyze/blob/master/EXCEPTION.md)

--- a/pages/blogpost-guide.mdx
+++ b/pages/blogpost-guide.mdx
@@ -7,7 +7,7 @@ on rescript-lang.org.
 
 ## Requirements
 
-Clone the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org) and follow the README instructions to run the local development server.
+Clone the [rescript-lang.org repo](https://github.com/rescript-lang/rescript-lang.org) and follow the README instructions to run the local development server.
 
 Open the [localhost:3000/blog](/blog) page to see the blog page.
 

--- a/pages/community/roadmap.mdx
+++ b/pages/community/roadmap.mdx
@@ -14,8 +14,8 @@ For latest development updates, please check out the [ReScript forum](https://fo
 
 Major v12.0 release (see [v12 milestone](https://github.com/rescript-lang/rescript-compiler/milestone/16)).
 
-* Move the [Rescript Core](https://github.com/rescript-association/rescript-core) standard library into the compiler / remove the OCaml standard library
-* A new build system tailored to ReScript's needs ([rewatch](https://github.com/teamwalnut/rewatch)) for better monorepo support and even faster compilation speed
-* Make it easier to create libraries for consumption from TypeScript with GenType
+- Move the [Rescript Core](https://github.com/rescript-lang/rescript-core) standard library into the compiler / remove the OCaml standard library
+- A new build system tailored to ReScript's needs ([rewatch](https://github.com/teamwalnut/rewatch)) for better monorepo support and even faster compilation speed
+- Make it easier to create libraries for consumption from TypeScript with GenType
 
 **Note:** Release goals may be subject to change.

--- a/pages/docs/guidelines/publishing-packages.mdx
+++ b/pages/docs/guidelines/publishing-packages.mdx
@@ -13,10 +13,12 @@ canonical: "/guidelines/publishing-npm-packages"
 Whenever you publish a ReScript package to npm, please follow the following guidelines:
 
 **Naming:**
+
 - Make sure to give a descriptive package name. We usually use `rescript-[name-of-js-lib]` for packages that bind to a specific JS library on npm.
 - Use names that are self explanatory (no weird marketing terms / fantasy words if possible).
 
 **Metadata:**
+
 - Add a proper `description` field in your `package.json` file
 - Add `rescript` as a keyword in your `package.json` file
 
@@ -26,4 +28,4 @@ Our package index will pick up the newest npm packages two times a day, so it mi
 
 We also maintain a hand-curated index of different resources that are not necessarily released on npm, such as plain URLs to independent files / repositories, or GitHub gists.
 
-You can submit your own resource by editing rescript-lang.org's [resource json file](https://github.com/rescript-association/rescript-lang.org/blob/master/data/packages_url_resources.json) file and submit a PR.
+You can submit your own resource by editing rescript-lang.org's [resource json file](https://github.com/rescript-lang/rescript-lang.org/blob/master/data/packages_url_resources.json) file and submit a PR.

--- a/pages/docs/manual/latest/installation.mdx
+++ b/pages/docs/manual/latest/installation.mdx
@@ -8,7 +8,7 @@ canonical: "/docs/manual/latest/installation"
 
 ## Notes
 
-With the instructions below, our new standard library [ReScript Core](https://github.com/rescript-association/rescript-core) will be included by default. (In ReScript 11, it comes as a separate npm package `@rescript/core`. In future versions, it will be included in the `rescript` npm package itself.)
+With the instructions below, our new standard library [ReScript Core](https://github.com/rescript-lang/rescript-core) will be included by default. (In ReScript 11, it comes as a separate npm package `@rescript/core`. In future versions, it will be included in the `rescript` npm package itself.)
 
 ## Prerequisites
 

--- a/pages/docs/manual/latest/migrate-to-v11.mdx
+++ b/pages/docs/manual/latest/migrate-to-v11.mdx
@@ -34,7 +34,7 @@ The old configuration filename `bsconfig.json` is deprecated. Rename `bsconfig.j
 
 ### ReScript Core standard library
 
-[ReScript Core](https://github.com/rescript-association/rescript-core) is ReScript's new standard library. It replaces the complete `Js` module as well as some of the more frequently used modules from `Belt` and is recommended to use with uncurried mode.
+[ReScript Core](https://github.com/rescript-lang/rescript-core) is ReScript's new standard library. It replaces the complete `Js` module as well as some of the more frequently used modules from `Belt` and is recommended to use with uncurried mode.
 
 It will be integrated into the compiler in a future version. In ReScript 11, it still needs to be installed manually:
 
@@ -63,12 +63,14 @@ Open it so it's available in the global scope.
 ```
 
 One major change to be aware of is that array access now returns an `option`.
+
 ```res
 let firstItem = myArray[0] // Some("hello")
 ```
+
 If you would like to not use an `option`, you can use [`Array.getUnsafe`](api/core/array#value-getUnsafe).
 
-For a detailed explanation on migration to ReScript Core, please refer to its [migration guide](https://github.com/rescript-association/rescript-core#migration). A semi-automated script is available as well.
+For a detailed explanation on migration to ReScript Core, please refer to its [migration guide](https://github.com/rescript-lang/rescript-core#migration). A semi-automated script is available as well.
 
 See ReScript Core API docs [here](api/core).
 

--- a/pages/docs/manual/latest/try.mdx
+++ b/pages/docs/manual/latest/try.mdx
@@ -6,4 +6,4 @@ canonical: "/docs/manual/latest/try"
 
 ## Try Online
 
-Our [Playground](/try) lets you try ReScript online, and comes with the [ReScript React bindings](/docs/react/latest/introduction) and the new [ReScript Core](https://github.com/rescript-association/rescript-core) standard library preinstalled.
+Our [Playground](/try) lets you try ReScript online, and comes with the [ReScript React bindings](/docs/react/latest/introduction) and the new [ReScript Core](https://github.com/rescript-lang/rescript-core) standard library preinstalled.

--- a/pages/docs/react/latest/introduction.mdx
+++ b/pages/docs/react/latest/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-lang/rescript-lang.org).

--- a/pages/docs/react/latest/styling.mdx
+++ b/pages/docs/react/latest/styling.mdx
@@ -120,7 +120,7 @@ let make = (~active: bool) => {
 }
 ```
 
-> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-association/rescript-lang.org) to get some more inspiration on usage patterns.
+> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-lang/rescript-lang.org) to get some more inspiration on usage patterns.
 
 ## CSS-in-JS
 

--- a/pages/docs/react/v0.10.0/introduction.mdx
+++ b/pages/docs/react/v0.10.0/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-lang/rescript-lang.org).

--- a/pages/docs/react/v0.10.0/styling.mdx
+++ b/pages/docs/react/v0.10.0/styling.mdx
@@ -14,7 +14,6 @@ React comes with builtin support for inline styles, but there are also a number 
 
 If they work in JS then they almost certainly work in ReScript. In the next few sections, we've shared some ideas for working with popular libraries. If you're interested in working with one you don't see here, search the [package index](https://rescript-lang.org/packages) or post in [the forum](https://forum.rescript-lang.org).
 
-
 ## Inline Styles
 
 This is the most basic form of styling, coming straight from the 90s. You can apply a `style` attribute to any DOM element with our `ReactDOM.Style.make` API:
@@ -62,11 +61,11 @@ As an example, let's say we have a CSS module like this:
 /* styles.module.css */
 
 .root {
-  color: red
+  color: red;
 }
 ```
 
-We now need to create a module binding that imports our styles as a JS object: 
+We now need to create a module binding that imports our styles as a JS object:
 
 ```res
 // {..} means we are handling a JS object with an unknown
@@ -78,7 +77,6 @@ let app = <div className={styles["root"]} />
 ```
 
 **Note:** `{..}` is an open [JS object type](/docs/manual/latest/object#type-declaration), which means the type checker will not type check correct classname usage. If you want to enforce compiler errors, replace `{..}` with a concrete JS object type, such as `{"root": string}`.
-
 
 ## CSS Utility Libraries
 
@@ -122,8 +120,7 @@ let make = (~active: bool) => {
 }
 ```
 
-> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-association/rescript-lang.org) to get some more inspiration on usage patterns.
-
+> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-lang/rescript-lang.org) to get some more inspiration on usage patterns.
 
 ## CSS-in-JS
 
@@ -181,7 +178,7 @@ let app = <div
 />
 ```
 
-Here we used the already existing `React.Style.t` type to enforce valid CSS attribute names. 
+Here we used the already existing `React.Style.t` type to enforce valid CSS attribute names.
 Last but not least, you can also bind to functions that let you use raw CSS directly:
 
 ```res

--- a/pages/docs/react/v0.11.0/introduction.mdx
+++ b/pages/docs/react/v0.11.0/introduction.mdx
@@ -27,4 +27,4 @@ All our documented examples can be compiled in our [ReScript Playground](/try) a
 ## Development
 
 - In case you are having any issues or if you want to help us out improving our bindings, check out our [rescript-react GitHub repository](https://github.com/rescript-lang/rescript-react).
-- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-association/rescript-lang.org).
+- For doc related issues, please go to the [rescript-lang.org repo](https://github.com/rescript-lang/rescript-lang.org).

--- a/pages/docs/react/v0.11.0/styling.mdx
+++ b/pages/docs/react/v0.11.0/styling.mdx
@@ -14,7 +14,6 @@ React comes with builtin support for inline styles, but there are also a number 
 
 If they work in JS then they almost certainly work in ReScript. In the next few sections, we've shared some ideas for working with popular libraries. If you're interested in working with one you don't see here, search the [package index](https://rescript-lang.org/packages) or post in [the forum](https://forum.rescript-lang.org).
 
-
 ## Inline Styles
 
 This is the most basic form of styling, coming straight from the 90s. You can apply a `style` attribute to any DOM element with our `ReactDOM.Style.make` API:
@@ -62,11 +61,11 @@ As an example, let's say we have a CSS module like this:
 /* styles.module.css */
 
 .root {
-  color: red
+  color: red;
 }
 ```
 
-We now need to create a module binding that imports our styles as a JS object: 
+We now need to create a module binding that imports our styles as a JS object:
 
 ```res
 // {..} means we are handling a JS object with an unknown
@@ -78,7 +77,6 @@ let app = <div className={styles["root"]} />
 ```
 
 **Note:** `{..}` is an open [JS object type](/docs/manual/latest/object#type-declaration), which means the type checker will not type check correct classname usage. If you want to enforce compiler errors, replace `{..}` with a concrete JS object type, such as `{"root": string}`.
-
 
 ## CSS Utility Libraries
 
@@ -122,8 +120,7 @@ let make = (~active: bool) => {
 }
 ```
 
-> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-association/rescript-lang.org) to get some more inspiration on usage patterns.
-
+> **Hint:** `rescript-lang.org` actually uses TailwindCSS under the hood! Check out our [codebase](https://github.com/rescript-lang/rescript-lang.org) to get some more inspiration on usage patterns.
 
 ## CSS-in-JS
 
@@ -181,7 +178,7 @@ let app = <div
 />
 ```
 
-Here we used the already existing `React.Style.t` type to enforce valid CSS attribute names. 
+Here we used the already existing `React.Style.t` type to enforce valid CSS attribute names.
 Last but not least, you can also bind to functions that let you use raw CSS directly:
 
 ```res

--- a/src/DocsOverview.res
+++ b/src/DocsOverview.res
@@ -37,7 +37,7 @@ let default = (~showVersionSelect=true) => {
     ("Package Index", "/packages"),
     ("rescript-react", "/docs/react/latest/introduction"),
     ("GenType", "/docs/manual/latest/typescript-integration"),
-    ("Reanalyze", "https://github.com/rescript-association/reanalyze"),
+    ("Reanalyze", "https://github.com/rescript-lang/reanalyze"),
   ]
 
   let tools = [("Syntax Lookup", "/syntax-lookup")]

--- a/src/Playground.res
+++ b/src/Playground.res
@@ -287,7 +287,7 @@ module ResultPane = {
           {React.string(
             "The compiler bundle API returned a result that couldn't be interpreted. Please open an issue on our ",
           )}
-          <Markdown.A href="https://github.com/rescript-association/rescript-lang.org/issues">
+          <Markdown.A href="https://github.com/rescript-lang/rescript-lang.org/issues">
             {React.string("issue tracker")}
           </Markdown.A>
           {React.string(".")}

--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -21,7 +21,7 @@ let ecosystem = [
   ("Package Index", "/packages"),
   ("rescript-react", "/docs/react/latest/introduction"),
   ("GenType", "/docs/manual/latest/typescript-integration"),
-  ("Reanalyze", "https://github.com/rescript-association/reanalyze"),
+  ("Reanalyze", "https://github.com/rescript-lang/reanalyze"),
 ]
 
 let tools = [("Syntax Lookup", "/syntax-lookup")]

--- a/src/common/OurUsers.res
+++ b/src/common/OurUsers.res
@@ -1,7 +1,7 @@
 type company = Logo({name: string, url: string, path: string})
 
 // NOTE: More details on how this works can be found in our README:
-// https://github.com/rescript-association/rescript-lang.org#how-to-add-your-company-logo-to-our-front-page
+// https://github.com/rescript-lang/rescript-lang.org#how-to-add-your-company-logo-to-our-front-page
 
 let companies = [
   Logo({

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -202,7 +202,7 @@ module DocsSection = {
         imgSrc: "/static/ic_reanalyze@2x.png",
         title: "Reanalyze",
         description: "Dead Code & Termination analysis",
-        href: "https://github.com/rescript-association/reanalyze",
+        href: "https://github.com/rescript-lang/reanalyze",
         isActive: _ => {
           false
         },

--- a/src/layouts/DocsLayout.res
+++ b/src/layouts/DocsLayout.res
@@ -139,7 +139,7 @@ let make = (
 
       let ghEditHref = switch canonical {
       | Some(canonical) =>
-        `https://github.com/rescript-association/rescript-lang.org/blob/master/pages${canonical}.mdx`->Some
+        `https://github.com/rescript-lang/rescript-lang.org/blob/master/pages${canonical}.mdx`->Some
       | None => None
       }
       (meta, ghEditHref)

--- a/src/layouts/LandingPageLayout.res
+++ b/src/layouts/LandingPageLayout.res
@@ -538,7 +538,7 @@ module TrustedBy = {
         ->React.array}
       </div>
       <a
-        href="https://github.com/rescript-association/rescript-lang.org/blob/master/src/common/OurUsers.res">
+        href="https://github.com/rescript-lang/rescript-lang.org/blob/master/src/common/OurUsers.res">
         <Button> {React.string("Add Your Logo")} </Button>
       </a>
       <div


### PR DESCRIPTION
As now everything moved to the [rescript-lang](https://github.com/orgs/rescript-lang/) org.