### PR TITLE
Migrate redirect entries to Cloudflare Pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,10 @@
+/community  /community/overview  308
+
+/bucklescript-rebranding  /blog/bucklescript-is-rebranding  308
+
+/docs/manual/latest/migrate-from-bucklescript-reason  /docs/manual/v10.0.0/migrate-from-bucklescript-reason  308
+/docs/manual/latest/unboxed                           /docs/manual/v10.0.0/unboxed                           308
+/docs/gentype/latest/introduction                     /docs/manual/latest/typescript-integration             308
+/docs/gentype/latest/getting-started                  /docs/manual/latest/typescript-integration             308
+/docs/gentype/latest/usage                            /docs/manual/latest/typescript-integration             308
+/docs/gentype/latest/supported-types                  /docs/manual/latest/typescript-integration             308


### PR DESCRIPTION
This fixes the community tab.

But I don't think the link doesn't necessarily rely on it
So https://github.com/rescript-lang/rescript-lang.org/pull/933