### PR TITLE
Fix docsearch version metatag

### DIFF
--- a/src/components/Meta.res
+++ b/src/components/Meta.res
@@ -74,7 +74,7 @@ let make = (
       name="docsearch:version"
       content={switch version {
       | Some(Version(v)) => v
-      | _ => "latest"
+      | _ => Constants.versions.latest
       }}
     />
   </Head>


### PR DESCRIPTION
The search doesn't work because the scraper can't
find the url with `latest` anymore.

This PR changes the meta tag, after merging I will update the crawler