### PR TITLE
feat: document `ref` for self-referencing

### DIFF
--- a/pages/docs/manual/v11.0.0/mutation.mdx
+++ b/pages/docs/manual/v11.0.0/mutation.mdx
@@ -73,3 +73,47 @@ Note that the previous binding `five` stays `5`, since it got the underlying ite
 ## Tip & Tricks
 
 Before reaching for `ref`, know that you can achieve lightweight, local "mutations" through [overriding let bindings](let-binding.md#binding-shadowing).
+
+### Self-Referencing Assignments
+
+There are scenarios where using a mutable `ref` binding becomes necessary, particularly when dealing with self-referencing. This is common when working with functions that return a value and accept a callback that uses that return value. In such cases, you need to initialize a mutable `ref` binding and then assign to it. Here's an example:
+
+<CodeTab labels={["ReScript", "JS Output"]}>
+
+```res example
+// hypothetic "showDialog" function shows the given `~content: JSX.element`
+// in the dialog. It returns a cleanup function that closes/removes the dialog.
+@val external showDialog: (~content: Jsx.element) => unit => unit = "showDialog"
+
+// We want render a "Close" button in the `~content` that will call the 
+// returned cleanup function when clicked. This requires a mutable binding.
+// First initialize it with a dummy function that has the same signature as
+// our cleanup function.
+let cleanupDialog = ref(() => ())
+
+// assign to the ref and self-refer to the value in the event handler
+cleanupDialog :=
+  showDialog(
+    ~content=<div>
+      <button onClick={_ => cleanupDialog.contents()}>
+        {React.string("Close")}
+      </button>
+    </div>,
+  )
+```
+```js
+var cleanupDialog = {
+  contents: (function () {})
+};
+
+cleanupDialog.contents = showDialog(JsxRuntime.jsx("div", {
+          children: JsxRuntime.jsx("button", {
+                children: "Close",
+                onClick: (function (param) {
+                    cleanupDialog.contents();
+                  })
+              })
+        }));
+```
+
+</CodeTab>


### PR DESCRIPTION
I encountered a problem with valid JS code that was hard to translate into rescript - the problem is [discussed here in the forum](https://forum.rescript-lang.org/t/recursion-in-a-function-argument-via-callback/5744/6) - it turned out the `ref` can help with self-referencing.

I promised to add this trick to the documentation, so here it is. Feel free to criticize 😸 

 I currently added it just to the v11 docs, once this passes validation, I will copy that into other versions as well. I assume it is useful for all versions where mutable let assignment exists?

Here is how it renders

![Screenshot 2025-01-03 at 12 38 39](https://github.com/user-attachments/assets/2e2cf3e0-83ec-4f0a-ae33-01d8ce2c1db2)
