### PR TITLE
Fix typo

### DIFF
--- a/pages/docs/manual/v12.0.0/external.mdx
+++ b/pages/docs/manual/v12.0.0/external.mdx
@@ -6,7 +6,7 @@ canonical: "/docs/manual/v12.0.0/external"
 
 # External (Bind to Any JS Library)
 
-`external` is the primary ReScript features for bringing in and using JavaScript values.
+`external` is the primary ReScript feature for bringing in and using JavaScript values.
 
 `external` is like a let binding, but:
 - The right side of `=` isn't a value; it's the name of the JS value you're referring to.


### PR DESCRIPTION
"is the primary ReScript features" → "is the primary ReScript feature"