### PR TITLE
load stdlib runtime in playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "scripts": {
     "dev": "next",
+    "res:watch": "rescript build -w",
     "build": "rescript && npm run update-index && next build",
     "test": "node scripts/test-examples.mjs && node scripts/test-hrefs.mjs",
     "reanalyze": "reanalyze -all-cmt .",

--- a/src/bindings/Webapi.res
+++ b/src/bindings/Webapi.res
@@ -27,6 +27,9 @@ module Element = {
   @send
   external postMessage: (contentWindow, string, ~targetOrigin: string=?) => unit = "postMessage"
 
+  @send
+  external postMessageAny: (contentWindow, 'a, ~targetOrigin: string=?) => unit = "postMessage"
+
   module Style = {
     @scope("style") @set external width: (Dom.element, string) => unit = "width"
     @scope("style") @set external height: (Dom.element, string) => unit = "height"

--- a/src/common/CompilerManagerHook.res
+++ b/src/common/CompilerManagerHook.res
@@ -40,6 +40,9 @@ module CdnMeta = {
 
   let getLibraryCmijUrl = (version, libraryName: string): string =>
     `https://cdn.rescript-lang.org/${Semver.toString(version)}/${libraryName}/cmij.js`
+
+  let getStdlibRuntimeUrl = (version, filename) =>
+    `https://cdn.rescript-lang.org/${Semver.toString(version)}/compiler-builtins/stdlib/${filename}`
 }
 
 module FinalResult = {

--- a/src/common/CompilerManagerHook.resi
+++ b/src/common/CompilerManagerHook.resi
@@ -27,6 +27,10 @@ type ready = {
   result: FinalResult.t,
 }
 
+module CdnMeta: {
+  let getStdlibRuntimeUrl: (Semver.t, string) => string
+}
+
 type state =
   | Init
   | SetupFailed(string)

--- a/src/common/EvalIFrame.res
+++ b/src/common/EvalIFrame.res
@@ -18,7 +18,6 @@ let srcDoc = `
         <script type="importmap">
           {
             "imports": {
-              "@jsxImportSource": "https://esm.sh/react@${reactVersion}",
               "react-dom/client": "https://esm.sh/react-dom@${reactVersion}/client",
               "react": "https://esm.sh/react@${reactVersion}",
               "react/jsx-runtime": "https://esm.sh/react@${reactVersion}/jsx-runtime"
@@ -36,11 +35,14 @@ let srcDoc = `
           window.JsxRuntime = JsxRuntime;
         </script>
         <script>
-          window.addEventListener("message", (event) => {
+          window.addEventListener("message", async (event) => {
             try {
               // https://rollupjs.org/troubleshooting/#avoiding-eval
-              const eval2 = eval;
-              eval2(event.data);
+              const imports = {};
+              for (const [key, path] of Object.entries(event.data.imports)) {
+                imports[key] = await import(path);
+              }
+              (Function(...Object.keys(imports), event.data.code))(...Object.values(imports));
             } catch (err) {
               console.error(err);
             }
@@ -67,7 +69,12 @@ let srcDoc = `
     </html>
   `
 
-let sendOutput = code => {
+type message = {
+  code: string,
+  imports: Dict.t<string>,
+}
+
+let sendOutput = (code, imports) => {
   open Webapi
 
   let frame = Document.document->Element.getElementById("iframe-eval")
@@ -75,7 +82,7 @@ let sendOutput = code => {
   switch frame {
   | Value(element) =>
     switch element->Element.contentWindow {
-    | Some(win) => win->Element.postMessage(code, ~targetOrigin="*")
+    | Some(win) => win->Element.postMessageAny({code, imports}, ~targetOrigin="*")
     | None => Console.error("contentWindow not found")
     }
   | Null | Undefined => Console.error("iframe not found")


### PR DESCRIPTION
With this PR and once https://github.com/rescript-lang/rescript/pull/7255 is merged, we'll be able to load stdlib runtime in the playground so that auto-run would work when the generated code imports things from the stdlib.