### PR TITLE
Fix markdown for logical OR (||);

### DIFF
--- a/pages/docs/manual/v10.0.0/overview.mdx
+++ b/pages/docs/manual/v10.0.0/overview.mdx
@@ -43,14 +43,14 @@ canonical: "/docs/manual/latest/overview"
 
 ### Boolean
 
-| JavaScript                                            | ReScript                                       |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | Same                                           |
-| `!true`                                               | Same                                           |
-| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
-| `a === b`, `a !== b`                                  | Same                                           |
-| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
-| `a == b`                                              | No equality with implicit casting (thankfully) |
+| JavaScript                            | ReScript                                       |
+| ------------------------------------- | ---------------------------------------------- |
+| `true`, `false`                       | Same                                           |
+| `!true`                               | Same                                           |
+| `\|\|`, `&&`, `<=`, `>=`, `<`, `>`    | Same                                           |
+| `a === b`, `a !== b`                  | Same                                           |
+| No deep equality (recursive compare)  | `a == b`, `a != b`                             |
+| `a == b`                              | No equality with implicit casting (thankfully) |
 
 ### Number
 
@@ -234,7 +234,7 @@ Float Division/Multiplication   | `2.0 /. 23.0 *. 1.0`                 | `2.0 / 
 Float Exponentiation            | `2.0 ** 3.0`                         | `Math.pow(2.0, 3.0)`
 String Concatenation            | `"Hello " ++ "World"`                | `"Hello " + "World"`
 Comparison                      | `>`, `<`, `>=`, `<=`                 | `>`, `<`, `>=`, `<=`
-Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&&`, <code>&#124;&#124;</code>
+Boolean operation               | `!`, `&&`, `\|\|`                    | `!`, `&&`, `\|\|`
 Shallow and deep Equality       | `===`, `==`                          | `===`, `==`
 List (disrecommended)           | `list{1, 2, 3}`                      | `{hd: 1, tl: {hd: 2, tl: {hd: 3, tl: 0}}}`
 List Prepend                    | `list{a1, a2, ...oldList}`           | `{hd: a1, tl: {hd: a2, tl: theRest}}`

--- a/pages/docs/manual/v11.0.0/overview.mdx
+++ b/pages/docs/manual/v11.0.0/overview.mdx
@@ -44,14 +44,14 @@ canonical: "/docs/manual/v11.0.0/overview"
 
 ### Boolean
 
-| JavaScript                                            | ReScript                                       |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | Same                                           |
-| `!true`                                               | Same                                           |
-| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
-| `a === b`, `a !== b`                                  | Same                                           |
-| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
-| `a == b`                                              | No equality with implicit casting (thankfully) |
+| JavaScript                           | ReScript                                       |
+| ------------------------------------ | ---------------------------------------------- |
+| `true`, `false`                      | Same                                           |
+| `!true`                              | Same                                           |
+| `\|\|`, `&&`, `<=`, `>=`, `<`, `>`   | Same                                           |
+| `a === b`, `a !== b`                 | Same                                           |
+| No deep equality (recursive compare) | `a == b`, `a != b`                             |
+| `a == b`                             | No equality with implicit casting (thankfully) |
 
 ### Number
 
@@ -243,7 +243,7 @@ The last expression of a block delimited by `{}` implicitly returns (including f
 | Float Exponentiation            | `2.0 ** 3.0`                         | `Math.pow(2.0, 3.0)`                       |
 | String Concatenation            | `"Hello " ++ "World"`                | `"Hello " + "World"`                       |
 | Comparison                      | `>`, `<`, `>=`, `<=`                 | `>`, `<`, `>=`, `<=`                       |
-| Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&&`, <code>&#124;&#124;</code>       |
+| Boolean operation               | `!`, `&&`, `\|\|`                    | `!`, `&&`, `\|\|`                          |
 | Shallow and deep Equality       | `===`, `==`                          | `===`, `==`                                |
 | List (disrecommended)           | `list{1, 2, 3}`                      | `{hd: 1, tl: {hd: 2, tl: {hd: 3, tl: 0}}}` |
 | List Prepend                    | `list{a1, a2, ...oldList}`           | `{hd: a1, tl: {hd: a2, tl: theRest}}`      |

--- a/pages/docs/manual/v12.0.0/overview.mdx
+++ b/pages/docs/manual/v12.0.0/overview.mdx
@@ -44,14 +44,14 @@ canonical: "/docs/manual/v12.0.0/overview"
 
 ### Boolean
 
-| JavaScript                                            | ReScript                                       |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | Same                                           |
-| `!true`                                               | Same                                           |
-| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
-| `a === b`, `a !== b`                                  | Same                                           |
-| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
-| `a == b`                                              | No equality with implicit casting (thankfully) |
+| JavaScript                            | ReScript                                       |
+| ------------------------------------- | ---------------------------------------------- |
+| `true`, `false`                       | Same                                           |
+| `!true`                               | Same                                           |
+| `\|\|`, `&&`, `<=`, `>=`, `<`, `>`    | Same                                           |
+| `a === b`, `a !== b`                  | Same                                           |
+| No deep equality (recursive compare)  | `a == b`, `a != b`                             |
+| `a == b`                              | No equality with implicit casting (thankfully) |
 
 ### Number
 
@@ -243,7 +243,7 @@ The last expression of a block delimited by `{}` implicitly returns (including f
 | Float Exponentiation            | `2.0 ** 3.0`                         | `Math.pow(2.0, 3.0)`                       |
 | String Concatenation            | `"Hello " ++ "World"`                | `"Hello " + "World"`                       |
 | Comparison                      | `>`, `<`, `>=`, `<=`                 | `>`, `<`, `>=`, `<=`                       |
-| Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&&`, <code>&#124;&#124;</code>       |
+| Boolean operation               | `!`, `&&`, `\|\|`                    | `!`, `&&`, `\|\|`                          |
 | Shallow and deep Equality       | `===`, `==`                          | `===`, `==`                                |
 | List (disrecommended)           | `list{1, 2, 3}`                      | `{hd: 1, tl: {hd: 2, tl: {hd: 3, tl: 0}}}` |
 | List Prepend                    | `list{a1, a2, ...oldList}`           | `{hd: a1, tl: {hd: a2, tl: theRest}}`      |

--- a/pages/docs/manual/v8.0.0/overview.mdx
+++ b/pages/docs/manual/v8.0.0/overview.mdx
@@ -43,14 +43,14 @@ canonical: "/docs/manual/latest/overview"
 
 ### Boolean
 
-| JavaScript                                            | Us                                             |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | Same                                           |
-| `!true`                                               | Same                                           |
-| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
-| `a === b`, `a !== b`                                  | Same                                           |
-| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
-| `a == b`                                              | No equality with implicit casting (thankfully) |
+| JavaScript                           | Us                                             |
+| ------------------------------------ | ---------------------------------------------- |
+| `true`, `false`                      | Same                                           |
+| `!true`                              | Same                                           |
+| `\|\|`, `&&`, `<=`, `>=`, `<`, `>`   | Same                                           |
+| `a === b`, `a !== b`                 | Same                                           |
+| No deep equality (recursive compare) | `a == b`, `a != b`                             |
+| `a == b`                             | No equality with implicit casting (thankfully) |
 
 ### Number
 
@@ -234,7 +234,7 @@ Float Division/Multiplication   | `2.0 /. 23.0 *. 1.0`                 | `2.0 / 
 Float Exponentiation            | `2.0 ** 3.0`                         | `Math.pow(2.0, 3.0)`
 String Concatenation            | `"Hello " ++ "World"`                | `"Hello " + "World"`
 Comparison                      | `>`, `<`, `>=`, `<=`                 | `>`, `<`, `>=`, `<=`
-Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&&`, <code>&#124;&#124;</code>
+Boolean operation               | `!`, `&&`, `\|\|`                    | `!`, `&&`, `\|\|`
 Shallow and deep Equality       | `===`, `==`                          | `===`, `==`
 List (disrecommended)           | `[1, 2, 3]`                          | `{hd: 1, tl: {hd: 2, tl: {hd: 3, tl: 0}}}`
 List Prepend                    | `[a1, a2, ...oldList]`               | `{hd: a1, tl: {hd: a2, tl: theRest}}`

--- a/pages/docs/manual/v9.0.0/overview.mdx
+++ b/pages/docs/manual/v9.0.0/overview.mdx
@@ -41,14 +41,14 @@ canonical: "/docs/manual/latest/overview"
 
 ### Boolean
 
-| JavaScript                                            | ReScript                                       |
-| ----------------------------------------------------- | ---------------------------------------------- |
-| `true`, `false`                                       | Same                                           |
-| `!true`                                               | Same                                           |
-| <code>&#124;&#124;</code>, `&&`, `<=`, `>=`, `<`, `>` | Same                                           |
-| `a === b`, `a !== b`                                  | Same                                           |
-| No deep equality (recursive compare)                  | `a == b`, `a != b`                             |
-| `a == b`                                              | No equality with implicit casting (thankfully) |
+| JavaScript                            | ReScript                                       |
+| ------------------------------------- | ---------------------------------------------- |
+| `true`, `false`                       | Same                                           |
+| `!true`                               | Same                                           |
+| `\|\|`, `&&`, `<=`, `>=`, `<`, `>`    | Same                                           |
+| `a === b`, `a !== b`                  | Same                                           |
+| No deep equality (recursive compare)  | `a == b`, `a != b`                             |
+| `a == b`                              | No equality with implicit casting (thankfully) |
 
 ### Number
 
@@ -232,7 +232,7 @@ Float Division/Multiplication   | `2.0 /. 23.0 *. 1.0`                 | `2.0 / 
 Float Exponentiation            | `2.0 ** 3.0`                         | `Math.pow(2.0, 3.0)`
 String Concatenation            | `"Hello " ++ "World"`                | `"Hello " + "World"`
 Comparison                      | `>`, `<`, `>=`, `<=`                 | `>`, `<`, `>=`, `<=`
-Boolean operation               | `!`, `&&`, <code>&#124;&#124;</code> | `!`, `&&`, <code>&#124;&#124;</code>
+Boolean operation               | `!`, `&&`, `\|\|`                    | `!`, `&&`, `\|\|`
 Shallow and deep Equality       | `===`, `==`                          | `===`, `==`
 List (disrecommended)           | `list{1, 2, 3}`                      | `{hd: 1, tl: {hd: 2, tl: {hd: 3, tl: 0}}}`
 List Prepend                    | `list{a1, a2, ...oldList}`           | `{hd: a1, tl: {hd: a2, tl: theRest}}`


### PR DESCRIPTION
Change that one:  
![изображение](https://github.com/user-attachments/assets/6eac0ce6-e5fd-4bca-a0dd-d1754813a9e4)

to this one:  
![изображение](https://github.com/user-attachments/assets/6c6c81e5-caf6-49fc-aa69-c0e47d89286c)
