### PR TITLE
Remove 11.1 banner

### DIFF
--- a/src/layouts/LandingPageLayout.res
+++ b/src/layouts/LandingPageLayout.res
@@ -707,14 +707,6 @@ let make = (~components=MarkdownComponents.default, ~children) => {
       <div className="text-gray-80 text-18 z">
         <Navigation isOverlayOpen setOverlayOpen />
         <div className="absolute w-full top-16">
-          // Delete this again, when ReScript 11.1 is out for some time.
-          <Banner>
-            {React.string("ReScript 11.1 is out! Read the ")}
-            <Next.Link href="/blog/release-11-1-0" className="underline">
-              {React.string("announcement blog post")}
-            </Next.Link>
-            {React.string(".")}
-          </Banner>
           <div className="relative overflow-hidden pb-32">
             <main className="mt-10 min-w-320 lg:align-center w-full">
               <MdxProvider components>


### PR DESCRIPTION
> // Delete this again, when ReScript 11.1 is out for some time.

I think it's been some time.