### PR TITLE
Remove broken link to Korean translation and adjust copy for translation page

### DIFF
--- a/pages/community/translations.mdx
+++ b/pages/community/translations.mdx
@@ -5,9 +5,8 @@ canonical: "/community/translation"
 ---
 
 # Translations
-The ReScript project is exclusively curated in English, but there are also community-driven projects for translating the docs into different languages.
-
-**Note:** Our documentation platform is still in the shaping process, and we don't have any bigger plans introducing i18n / translation features just yet. If you decide to translate our resources, please make sure to follow SEO best practises and most importantly, add [canonical](https://moz.com/learn/seo/canonicalization) references to point to the original source, otherwise we might get mixed results with SEO / google search. When in doubt, please reach out to us [in the forum](https://forum.rescript-lang.org).
-## Languages
-
-- [Korean/한국어](https://green-labs.github.io/rescript-in-korean/)
+The ReScript project is exclusively curated in English and our documentation platform is still in the shaping process. 
+We currently don't have plans introducing i18n / translation features just yet. 
+We welcome any community efforts to translate our resources. Please make sure to follow SEO best practises and most importantly, 
+add [canonical](https://moz.com/learn/seo/canonicalization) references to point to the original source, otherwise we might get mixed results with SEO / google search. 
+When in doubt, please reach out to us [in the forum](https://forum.rescript-lang.org).


### PR DESCRIPTION
I noticed that this link was broken the related repo hasn't been updated in a couple of years.