### PR TITLE
add community link back to mobile nav

### DIFF
--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -380,13 +380,11 @@ module MobileNav = {
             {React.string("Blog")}
           </Link>
         </li>
-         <li className=base>
-           <Link href="/community"  className={linkOrActiveLink(~target="/community", ~route)}>
-
-               {React.string("Community")}
-
-           </Link>
-         </li>
+        <li className=base>
+          <Link href="/community" className={linkOrActiveLink(~target="/community", ~route)}>
+            {React.string("Community")}
+          </Link>
+        </li>
         <li className=base>
           <a href=Constants.xHref rel="noopener noreferrer" className=extLink>
             {React.string("X")}

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -380,7 +380,6 @@ module MobileNav = {
             {React.string("Blog")}
           </Link>
         </li>
-        /*
          <li className=base>
            <Link href="/community"  className={linkOrActiveLink(~target="/community", ~route)}>
 
@@ -388,7 +387,6 @@ module MobileNav = {
 
            </Link>
          </li>
- */
         <li className=base>
           <a href=Constants.xHref rel="noopener noreferrer" className=extLink>
             {React.string("X")}


### PR DESCRIPTION
I noticed that there was no way to get to the community page from a mobile device. The link was commented out, so I just added it back. I'm not sure if there was a reason to remove it.