### PR TITLE
Update interop-cheatsheet.mdx

### DIFF
--- a/pages/docs/manual/v11.0.0/interop-cheatsheet.mdx
+++ b/pages/docs/manual/v11.0.0/interop-cheatsheet.mdx
@@ -159,7 +159,7 @@ var result3 = Caml_option.nullable_to_opt(10);
 
 ```res example
 @send external map: (array<'a>, 'a => 'b) => array<'b> = "map"
-@send external filter: (array<'a>, 'a => 'b) => array<'b> = "filter"
+@send external filter: (array<'a>, 'a => bool) => array<'b> = "filter"
 [1, 2, 3]
   ->map(a => a + 1)
   ->filter(a => mod(a, 2) == 0)


### PR DESCRIPTION
had a small mistake: the return type of filter's callback should be bool, not 'b.