### PR TITLE
Hide focus outline in documentation search bar

### DIFF
--- a/styles/_docsearch.css
+++ b/styles/_docsearch.css
@@ -89,7 +89,7 @@
 }
 
 .DocSearch-Input {
-  @apply w-full appearance-none outline-none bg-transparent border-none flex-1 text-14 px-4;
+  @apply h-14 w-full appearance-none focus:outline-none bg-transparent border-none flex-1 text-14 px-4;
 }
 
 .DocSearch-Input::placeholder {


### PR DESCRIPTION
The documentation search input already had an `outline-none` Tailwind class, but due to conflicting styles in the same stylesheet with higher specificity, it had no effect.

By changing it to `focus:outline-none`, this rule now has high enough specificity to actually disable outlines.

I've also increased the input's height to 3.5rem, which makes it much easier to click on.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/823163a3-8791-441e-88a6-3efca9f3e02f) | ![image](https://github.com/user-attachments/assets/1706f7bd-af7d-4c06-95f6-ca38aa972f0e)

