### PR TITLE
Restructure docs

### DIFF
--- a/data/sidebar_manual_v1200.json
+++ b/data/sidebar_manual_v1200.json
@@ -2,9 +2,31 @@
   "Overview": [
     "introduction",
     "installation",
-    "migrate-to-v11",
     "editor-plugins",
-    "try"
+    "faq",
+    "llms"
+  ],
+  "Guides": [
+    "converting-from-js",
+    "newcomer-examples",
+    "project-structure"
+  ],
+  "JavaScript Interop": [
+    "interop-cheatsheet",
+    "embed-raw-javascript",
+    "shared-data-types",
+    "external",
+    "bind-to-js-object",
+    "bind-to-js-function",
+    "import-from-export-to-js",
+    "bind-to-global-js-values",
+    "json",
+    "inlining-constants",
+    "use-illegal-identifier-names",
+    "generate-converters-accessors",
+    "browser-support-polyfills",
+    "libraries",
+    "typescript-integration"
   ],
   "Language Features": [
     "overview",
@@ -35,27 +57,7 @@
     "reserved-keywords",
     "equality-comparison"
   ],
-  "Advanced Features": [
-    "extensible-variant",
-    "scoped-polymorphic-types"
-  ],
-  "JavaScript Interop": [
-    "interop-cheatsheet",
-    "embed-raw-javascript",
-    "shared-data-types",
-    "external",
-    "bind-to-js-object",
-    "bind-to-js-function",
-    "import-from-export-to-js",
-    "bind-to-global-js-values",
-    "json",
-    "inlining-constants",
-    "use-illegal-identifier-names",
-    "generate-converters-accessors",
-    "browser-support-polyfills",
-    "libraries",
-    "typescript-integration"
-  ],
+
   "Build System": [
     "build-overview",
     "build-configuration",
@@ -66,13 +68,8 @@
     "build-performance",
     "warning-numbers"
   ],
-  "Guides": [
-    "converting-from-js"
-  ],
-  "Extra": [
-    "newcomer-examples",
-    "project-structure",
-    "faq",
-    "llms"
+  "Advanced Features": [
+    "extensible-variant",
+    "scoped-polymorphic-types"
   ]
 }

--- a/pages/docs/manual/v12.0.0/api.mdx
+++ b/pages/docs/manual/v12.0.0/api.mdx
@@ -10,5 +10,5 @@ In ReScript 11, it is shipped as a separate npm package `@rescript/core` that is
 
 ReScript ships with these two additional modules in its standard library:
 
-- [Belt](api/belt): immutable collections and extra helpers not available in JavaScript / [Core](api/core).
+- [Belt](api/belt): immutable collections and extra helpers not available in [Core](api/core).
 - [Dom](api/dom): Dom related types and modules. Contains our standardized types used by various userland DOM bindings.

--- a/pages/docs/manual/v12.0.0/api.mdx
+++ b/pages/docs/manual/v12.0.0/api.mdx
@@ -12,7 +12,3 @@ ReScript ships with these two additional modules in its standard library:
 
 - [Belt](api/belt): immutable collections and extra helpers not available in JavaScript / [Core](api/core).
 - [Dom](api/dom): Dom related types and modules. Contains our standardized types used by various userland DOM bindings.
-
-## Legacy Modules
-
-The [Js](api/js) module is superseded by [Core](api/core).

--- a/pages/docs/manual/v12.0.0/editor-code-analysis.mdx
+++ b/pages/docs/manual/v12.0.0/editor-code-analysis.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Editor"
-metaTitle: "Editor"
+title: "Dead Code Analysis in ReScript"
+metaTitle: "Dead Code Analysis in ReScript"
 description: "Documentation about ReScript editor plugins and code analysis"
 canonical: "/docs/manual/v12.0.0/editor-plugins"
 ---
 
-# Guide: Dead Code Analysis in ReScript
+# Dead Code Analysis in ReScript
 
 This guide provides a detailed walkthrough on how to leverage ReScript’s powerful dead code analysis tools to maintain a clean, efficient, and distraction-free codebase.
 

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -177,27 +177,6 @@ module DocsSection = {
           }
         },
       },
-      {
-        imgSrc: "/static/ic_gentype@2x.png",
-        title: "GenType",
-        description: "Seamless TypeScript integration",
-        href: `/docs/manual/${version}/typescript-integration`,
-        isActive: url => {
-          switch url.fullpath {
-          | ["docs", "manual", _, "typescript-integration"] => true
-          | _ => false
-          }
-        },
-      },
-      {
-        imgSrc: "/static/ic_reanalyze@2x.png",
-        title: "Reanalyze",
-        description: "Dead Code & Termination analysis",
-        href: "https://github.com/rescript-lang/reanalyze",
-        isActive: _ => {
-          false
-        },
-      },
     ]
 
     let languageManualColumn =
@@ -532,9 +511,17 @@ let make = (~fixed=true, ~isOverlayOpen: bool, ~setOverlayOpen: (bool => bool) =
           <div
             className="flex ml-10 space-x-5 w-full max-w-320"
             style={ReactDOMStyle.make(~maxWidth="26rem", ())}>
-            {collapsibleElements->React.array}
+            <Link
+              href={`/docs/manual/${version}/introduction`}
+              className={linkOrActiveApiSubroute(~route)}>
+              {React.string("Docs")}
+            </Link>
             <Link href={`/docs/manual/${version}/api`} className={linkOrActiveApiSubroute(~route)}>
               {React.string("API")}
+            </Link>
+            <Link
+              href={`/docs/react/latest/introduction`} className={linkOrActiveApiSubroute(~route)}>
+              {React.string("React")}
             </Link>
             <Link
               href="/try"

--- a/src/components/Navigation.res
+++ b/src/components/Navigation.res
@@ -16,6 +16,10 @@ let linkOrActiveApiSubroute = (~route) => {
   }
 }
 
+let isActiveLink = (~route: string, ~href: string) => {
+  route == href ? activeLink : link
+}
+
 module CollapsibleLink = {
   // KeepOpen = Menu has been opened and should stay open
   type state =
@@ -513,14 +517,17 @@ let make = (~fixed=true, ~isOverlayOpen: bool, ~setOverlayOpen: (bool => bool) =
             style={ReactDOMStyle.make(~maxWidth="26rem", ())}>
             <Link
               href={`/docs/manual/${version}/introduction`}
-              className={linkOrActiveApiSubroute(~route)}>
+              className={isActiveLink(~route, ~href=`/docs/manual/${version}/introduction`)}>
               {React.string("Docs")}
             </Link>
-            <Link href={`/docs/manual/${version}/api`} className={linkOrActiveApiSubroute(~route)}>
+            <Link
+              href={`/docs/manual/${version}/api`}
+              className={isActiveLink(~route, ~href=`/docs/manual/${version}/api`)}>
               {React.string("API")}
             </Link>
             <Link
-              href={`/docs/react/latest/introduction`} className={linkOrActiveApiSubroute(~route)}>
+              href={`/docs/react/latest/introduction`}
+              className={isActiveLink(~route, ~href=`/docs/react/latest/introduction`)}>
               {React.string("React")}
             </Link>
             <Link

--- a/src/layouts/ApiOverviewLayout.res
+++ b/src/layouts/ApiOverviewLayout.res
@@ -5,12 +5,9 @@ let makeCategories: string => array<Sidebar.Category.t> = version => [
     name: "",
     items: [
       {name: "Overview", href: `/docs/manual/${version}/api`},
+      {name: "Core", href: `/docs/manual/${version}/api/core`},
       {name: "Syntax Lookup", href: "/syntax-lookup"},
     ],
-  },
-  {
-    name: "Standard Library",
-    items: [{name: "Core", href: `/docs/manual/${version}/api/core`}],
   },
   {
     name: "Additional Libraries",

--- a/src/layouts/ApiOverviewLayout.res
+++ b/src/layouts/ApiOverviewLayout.res
@@ -2,16 +2,15 @@ module Sidebar = SidebarLayout.Sidebar
 
 let makeCategories: string => array<Sidebar.Category.t> = version => [
   {
-    name: "Introduction",
-    items: [{name: "Overview", href: `/docs/manual/${version}/api`}],
+    name: "",
+    items: [
+      {name: "Overview", href: `/docs/manual/${version}/api`},
+      {name: "Syntax Lookup", href: "/syntax-lookup"},
+    ],
   },
   {
     name: "Standard Library",
     items: [{name: "Core", href: `/docs/manual/${version}/api/core`}],
-  },
-  {
-    name: "Syntax Lookup",
-    items: [{name: "Core", href: "/syntax-lookup"}],
   },
   {
     name: "Additional Libraries",

--- a/src/layouts/ApiOverviewLayout.res
+++ b/src/layouts/ApiOverviewLayout.res
@@ -10,15 +10,15 @@ let makeCategories: string => array<Sidebar.Category.t> = version => [
     items: [{name: "Core", href: `/docs/manual/${version}/api/core`}],
   },
   {
+    name: "Syntax Lookup",
+    items: [{name: "Core", href: "/syntax-lookup"}],
+  },
+  {
     name: "Additional Libraries",
     items: [
       {name: "Belt", href: `/docs/manual/${version}/api/belt`},
       {name: "Dom", href: `/docs/manual/${version}/api/dom`},
     ],
-  },
-  {
-    name: "Legacy Modules",
-    items: [{name: "Js", href: `/docs/manual/${version}/api/js`}],
   },
 ]
 


### PR DESCRIPTION
Miro board: https://miro.com/app/board/uXjVI63RQc0=/

- Reorder the sidebar for the docs page to simplify categories and push advanced features to the bottom
- Removes the dropdown nav when clicking on the docs link and goes directly to the docs page
- Removes the JS library from the api sidebar and flatten the link structure
- adds a link to the syntax search to the api sidebar, since the doc dropdown has been removed
- adds a link to React in the top nav, to make it more prominent and since the doc dropdown has been removed

![image](https://github.com/user-attachments/assets/c5bf33b7-d63b-4e7d-9c82-3a9a4fe5dc48)


| Docs sidebar top                                                                           | Docs sidebar bottom                                                                       | Api sidebar                                                                               |
|--------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/faba8676-4b31-4fcd-88ab-21cb1e2329d3)| ![image](https://github.com/user-attachments/assets/a2a3e6db-aefa-4759-b5a6-df491622af15) | ![image](https://github.com/user-attachments/assets/f8791e18-bc66-4a02-aedb-b4a8bf2da73d) |

