### PR TITLE
Fix variant design decisions

### DIFF
--- a/pages/docs/manual/v12.0.0/variant.mdx
+++ b/pages/docs/manual/v12.0.0/variant.mdx
@@ -781,12 +781,15 @@ There's a linear amount of branch checking here (`O(n)`). Compare this to using 
 ```res example
 type animal = Dog | Cat | Bird
 let data = Dog
-let logData = data => switch data {
-| Dog => Console.log("Wof")
-| Cat => Console.log("Meow")
-| Bird => Console.log("Kashiiin")
+let logData = data => {
+  switch data {
+  | Dog => Console.log("Wof")
+  | Cat => Console.log("Meow")
+  | Bird => Console.log("Kashiiin")
+  }
 }
 logData(data)
+
 ```
 ```js
 function logData(data) {

--- a/pages/docs/manual/v12.0.0/variant.mdx
+++ b/pages/docs/manual/v12.0.0/variant.mdx
@@ -762,13 +762,16 @@ Performance-wise, a variant can potentially tremendously speed up your program's
 
 ```js
 let data = 'dog'
-if (data === 'dog') {
-  ...
-} else if (data === 'cat') {
-  ...
-} else if (data === 'bird') {
-  ...
+function logData(data) {
+  if (data === 'dog') {
+    ...
+  } else if (data === 'cat') {
+    ...
+  } else if (data === 'bird') {
+    ...
+  }
 }
+logData(data)
 ```
 
 There's a linear amount of branch checking here (`O(n)`). Compare this to using a ReScript variant:
@@ -778,16 +781,29 @@ There's a linear amount of branch checking here (`O(n)`). Compare this to using 
 ```res example
 type animal = Dog | Cat | Bird
 let data = Dog
-switch data {
+let logData = data => switch data {
 | Dog => Console.log("Wof")
 | Cat => Console.log("Meow")
 | Bird => Console.log("Kashiiin")
 }
+logData(data)
 ```
 ```js
-console.log("Wof");
+function logData(data) {
+  switch (data) {
+    case "Dog" :
+      console.log("Wof");
+      return;
+    case "Cat" :
+      console.log("Meow");
+      return;
+    case "Bird" :
+      console.log("Kashiiin");
+      return;
+  }
+}
 
-var data = "Dog";
+logData("Dog");
 ```
 
 </CodeTab>


### PR DESCRIPTION
Made the examples functions instead so the ReScript one is not inlined.

Closes https://github.com/rescript-lang/rescript-lang.org/issues/954