### PR TITLE
fix: remove margin override

### DIFF
--- a/src/layouts/SidebarLayout.res
+++ b/src/layouts/SidebarLayout.res
@@ -136,9 +136,6 @@ module Sidebar = {
     <>
       <div
         id="sidebar"
-        style={{
-          marginTop: "112px",
-        }}
         className={(
           isOpen ? "fixed w-full left-0 h-full z-20 min-w-320" : "hidden "
         ) ++ " overflow-x-hidden md:block md:w-48 md:-ml-4 lg:w-1/5 md:h-auto md:relative overflow-y-visible bg-white mt-28 md:mt-0"}>


### PR DESCRIPTION
At some point tailwind decided to pick up a class that wasn't working before and the margin doubled because of it for the sidebar on the docs page.

## Before
![image](https://github.com/user-attachments/assets/fa8c63c0-1b7f-4ee4-be8d-eeb4f64bf735)

## After
![image](https://github.com/user-attachments/assets/4a7039cb-dcf1-4f30-8277-a8f5c46b18ce)
