### PR TITLE
Update syntax lookup links to getters and setters decorators explanation

### DIFF
--- a/misc_docs/syntax/decorator_get.mdx
+++ b/misc_docs/syntax/decorator_get.mdx
@@ -28,4 +28,4 @@ var name = window.name;
 
 ### References
 
-- [Bind using Special `@bs` Getters & Setters](/docs/manual/latest/bind-to-js-object#bind-using-special-bs-getters--setters)
+- [Bind Using Special Getter and Setter Attributes](/docs/manual/latest/bind-to-js-object#bind-using-special-getter-and-setter-attributes)

--- a/misc_docs/syntax/decorator_get_index.mdx
+++ b/misc_docs/syntax/decorator_get_index.mdx
@@ -42,4 +42,4 @@ var value = o["y"];
 
 ### References
 
-- [Bind using Special `@bs` Getters & Setters](/docs/manual/latest/bind-to-js-object#bind-using-special-bs-getters--setters)
+- [Bind Using Special Getter and Setter Attributes](/docs/manual/latest/bind-to-js-object#bind-using-special-getter-and-setter-attributes)

--- a/misc_docs/syntax/decorator_set.mdx
+++ b/misc_docs/syntax/decorator_set.mdx
@@ -28,4 +28,4 @@ window.name = "MyWindow";
 
 ### References
 
-- [Bind using Special `@bs` Getters & Setters](/docs/manual/latest/bind-to-js-object#bind-using-special-bs-getters--setters)
+- [Bind Using Special Getter and Setter Attributes](/docs/manual/latest/bind-to-js-object#bind-using-special-getter-and-setter-attributes)

--- a/misc_docs/syntax/decorator_set_index.mdx
+++ b/misc_docs/syntax/decorator_set_index.mdx
@@ -42,4 +42,4 @@ var value = o["y"];
 
 ### References
 
-- [Bind using Special `@bs` Getters & Setters](/docs/manual/latest/bind-to-js-object#bind-using-special-bs-getters--setters)
+- [Bind Using Special Getter and Setter Attributes](/docs/manual/latest/bind-to-js-object#bind-using-special-getter-and-setter-attributes)


### PR DESCRIPTION
The syntax lookup pages for getters and setters decorators used an outdated hash in their links to the relevant docs.