### PR TITLE
fix `docsearch:version` metatag

### DIFF
--- a/src/components/Meta.res
+++ b/src/components/Meta.res
@@ -72,6 +72,8 @@ let make = (
       name="docsearch:version"
       content={switch version {
       | Some(Version(v)) => v
+      | Some(Latest) => Constants.versions.latest
+      | Some(Next) => Constants.versions.next
       | _ => Constants.versions.latest
       }}
     />


### PR DESCRIPTION
For the crawler to index content from version v12