### PR TITLE
fix react url

### DIFF
--- a/src/common/Constants.res
+++ b/src/common/Constants.res
@@ -28,7 +28,7 @@ let nextVersion =
 let stdlibVersions =
   versions.latest === "v11.0.0" ? [latestVersion] : [("v11.0.0", "v11"), latestVersion]
 
-let latestReactVersion = "v0.12.0"
+let latestReactVersion = "latest"
 let allReactVersions = [
   ("latest", latestReactVersion),
   ("v0.11.0", "v0.11.0"),


### PR DESCRIPTION
The React page doesn't use a version number, it uses `latest`

![image](https://github.com/user-attachments/assets/356f3946-4f25-4f4a-8707-ade65e561a56)


Bug add in #1070