### PR TITLE
Enable auto-run by default in playground UI

### DIFF
--- a/src/common/CompilerManagerHook.res
+++ b/src/common/CompilerManagerHook.res
@@ -446,7 +446,7 @@ let useCompilerManager = (
                 errors: [],
                 result: FinalResult.Nothing,
                 logs: [],
-                autoRun: false,
+                autoRun: true,
                 validReactCode: false,
               }))
             | Error(errs) =>


### PR DESCRIPTION
One less click to get to the output of a playground link (click Output vs Checking AutoRun then clicking Output) and the accompanying very-cool live-edit experience.

I spent a few hours trying to get "Output as the default tab, with Results filled in once page loads and can run the code" working seamlessly too (i.e. 0 clicks), but am struggling with waiting for the output tab's iframe to be loaded before triggering the "RunCode" functionality. 