### PR TITLE
Ignore format check of API json files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+data/api/**/*.json


### PR DESCRIPTION
Now that we have a format check, every API docs update broke the build. Let's rather not format autogenerated JSON files here.