### PR TITLE
Typo: unescaped Markdown

### DIFF
--- a/pages/docs/manual/v11.0.0/migrate-to-v11.mdx
+++ b/pages/docs/manual/v11.0.0/migrate-to-v11.mdx
@@ -108,7 +108,7 @@ Below is an excerpt from the compiler changelog about all the breaking changes o
   Also, `(. int) => string => bool` is not equivalen to `(. int, string) => bool` anymore.
   These are only breaking changes for unformatted code.
 - Exponentiation operator `**` is now right-associative. `2. ** 3. ** 2.` now compile to `Math.pow(2, Math.pow(3, 2))` and not anymore `Math.pow(Math.pow(2, 3), 2)`. Parentheses can be used to change precedence.
-- Stop mangling object field names. If you had objects with field names containing "\__" or leading "_", they won't be mangled in the compiled JavaScript and represented as it is without changes. https://github.com/rescript-lang/rescript/pull/6354
+- Stop mangling object field names. If you had objects with field names containing "\_\_" or leading "\_", they won't be mangled in the compiled JavaScript and represented as it is without changes. https://github.com/rescript-lang/rescript/pull/6354
 - `$$default` is no longer exported from the generated JavaScript when using default exports. https://github.com/rescript-lang/rescript/pull/6328
 - `-bs-super-errors` flag has been deprecated along with Super_errors. https://github.com/rescript-lang/rescript/pull/6243
 - Remove unsafe `` j`$(a)$(b)` `` interpolation deprecated in compiler version 10 https://github.com/rescript-lang/rescript/pull/6068

--- a/pages/docs/manual/v12.0.0/migrate-to-v11.mdx
+++ b/pages/docs/manual/v12.0.0/migrate-to-v11.mdx
@@ -108,7 +108,7 @@ Below is an excerpt from the compiler changelog about all the breaking changes o
   Also, `(. int) => string => bool` is not equivalen to `(. int, string) => bool` anymore.
   These are only breaking changes for unformatted code.
 - Exponentiation operator `**` is now right-associative. `2. ** 3. ** 2.` now compile to `Math.pow(2, Math.pow(3, 2))` and not anymore `Math.pow(Math.pow(2, 3), 2)`. Parentheses can be used to change precedence.
-- Stop mangling object field names. If you had objects with field names containing "\__" or leading "_", they won't be mangled in the compiled JavaScript and represented as it is without changes. https://github.com/rescript-lang/rescript-compiler/pull/6354
+- Stop mangling object field names. If you had objects with field names containing "\_\_" or leading "\_", they won't be mangled in the compiled JavaScript and represented as it is without changes. https://github.com/rescript-lang/rescript-compiler/pull/6354
 - `$$default` is no longer exported from the generated JavaScript when using default exports. https://github.com/rescript-lang/rescript-compiler/pull/6328
 - `-bs-super-errors` flag has been deprecated along with Super_errors. https://github.com/rescript-lang/rescript-compiler/pull/6243
 - Remove unsafe `` j`$(a)$(b)` `` interpolation deprecated in compiler version 10 https://github.com/rescript-lang/rescript-compiler/pull/6068


### PR DESCRIPTION
I wonder how many ReScript users migrating to v11 had to have read this typo without any of them ending up fixing it...

BTW, please squash the two commits into one. I edited using the GitHub web UI, which doesn't seem to let you edit multiple files in one commit. Let me know if I need to change my fork's settings for the commit message.

EDIT: Had messed up some Git stuff, but fixed it now.