### PR TITLE
Update refs-and-the-dom.mdx

### DIFF
--- a/pages/docs/react/latest/refs-and-the-dom.mdx
+++ b/pages/docs/react/latest/refs-and-the-dom.mdx
@@ -52,7 +52,7 @@ let make = () => {
 }
 ```
 
-The example above defines a binding `clicks` of type `React.ref(int)`. Note how changing the value `clicks.current` doesn't trigger any re-rendering of the component.
+The example above defines a binding `clicks` of type `React.ref<int>`. Note how changing the value `clicks.current` doesn't trigger any re-rendering of the component.
 
 ## Accessing Refs
 


### PR DESCRIPTION
`React.ref(int)` isn't a type, but `React.ref<int>` is.