### PR TITLE
refactor: add order and section to language manual frontmatter

### DIFF
--- a/pages/docs/manual/v12.0.0/array-and-list.mdx
+++ b/pages/docs/manual/v12.0.0/array-and-list.mdx
@@ -2,6 +2,8 @@
 title: "Array & List"
 description: "Arrays and List data structures"
 canonical: "/docs/manual/v12.0.0/array-and-list"
+section: "Language Features"
+order: 12
 ---
 
 # Array and List

--- a/pages/docs/manual/v12.0.0/async-await.mdx
+++ b/pages/docs/manual/v12.0.0/async-await.mdx
@@ -2,6 +2,8 @@
 title: "Async / Await"
 description: "Async / await for asynchronous operations"
 canonical: "/docs/manual/v12.0.0/async-await"
+section: "Language Features"
+order: 22
 ---
 
 <!-- This prelude is used in many different followup examples, so we use it to shorten the noise of the example code. -->

--- a/pages/docs/manual/v12.0.0/attribute.mdx
+++ b/pages/docs/manual/v12.0.0/attribute.mdx
@@ -2,6 +2,8 @@
 title: "Attribute (Decorator)"
 description: "Annotations in ReScript"
 canonical: "/docs/manual/v12.0.0/attribute"
+section: "Language Features"
+order: 26
 ---
 
 # Attribute (Decorator)

--- a/pages/docs/manual/v12.0.0/bind-to-global-js-values.mdx
+++ b/pages/docs/manual/v12.0.0/bind-to-global-js-values.mdx
@@ -2,6 +2,8 @@
 title: "Bind to Global JS Values"
 description: "JS interop with global JS values in ReScript"
 canonical: "/docs/manual/v12.0.0/bind-to-global-js-values"
+section: "JavaScript Interop"
+order: 8
 ---
 
 # Bind to Global JS Values

--- a/pages/docs/manual/v12.0.0/bind-to-js-function.mdx
+++ b/pages/docs/manual/v12.0.0/bind-to-js-function.mdx
@@ -2,6 +2,8 @@
 title: "Bind to JS Function"
 description: "JS interop with functions in ReScript"
 canonical: "/docs/manual/v12.0.0/bind-to-js-function"
+section: "JavaScript Interop"
+order: 6
 ---
 
 # Function

--- a/pages/docs/manual/v12.0.0/bind-to-js-object.mdx
+++ b/pages/docs/manual/v12.0.0/bind-to-js-object.mdx
@@ -2,6 +2,8 @@
 title: "Bind to JS Object"
 description: "Interop with JS objects in ReScript"
 canonical: "/docs/manual/v12.0.0/bind-to-js-object"
+section: "JavaScript Interop"
+order: 5
 ---
 
 # Bind to JS Object

--- a/pages/docs/manual/v12.0.0/browser-support-polyfills.mdx
+++ b/pages/docs/manual/v12.0.0/browser-support-polyfills.mdx
@@ -2,6 +2,8 @@
 title: "Browser Support & Polyfills"
 description: "Note on browser support in ReScript"
 canonical: "/docs/manual/v12.0.0/browser-support-polyfills"
+section: "JavaScript Interop"
+order: 13
 ---
 
 # Browser Support & Polyfills

--- a/pages/docs/manual/v12.0.0/build-configuration-schema.mdx
+++ b/pages/docs/manual/v12.0.0/build-configuration-schema.mdx
@@ -3,6 +3,8 @@ title: "Configuration Schema"
 metaTitle: "Build System Configuration Schema"
 description: "Schema exploration widget for the ReScript configuration file"
 canonical: "/docs/manual/v12.0.0/build-configuration-schema"
+section: "Build System"
+order: 3
 ---
 
 import dynamic from "next/dynamic";

--- a/pages/docs/manual/v12.0.0/build-configuration.mdx
+++ b/pages/docs/manual/v12.0.0/build-configuration.mdx
@@ -3,6 +3,8 @@ title: "Configuration"
 metaTitle: "Build System Configuration"
 description: "Details about the configuration of the ReScript build system (rescript.json)"
 canonical: "/docs/manual/v12.0.0/build-configuration"
+section: "Build System"
+order: 2
 ---
 
 # Configuration

--- a/pages/docs/manual/v12.0.0/build-external-stdlib.mdx
+++ b/pages/docs/manual/v12.0.0/build-external-stdlib.mdx
@@ -3,6 +3,8 @@ title: "External Stdlib"
 metaTitle: "External Stdlib"
 description: "Configuring an external ReScript stdlib package"
 canonical: "/docs/manual/v12.0.0/build-external-stdlib"
+section: "Build System"
+order: 4
 ---
 
 # External Stdlib

--- a/pages/docs/manual/v12.0.0/build-overview.mdx
+++ b/pages/docs/manual/v12.0.0/build-overview.mdx
@@ -3,6 +3,8 @@ title: "Overview"
 metaTitle: "Build System Overview"
 description: "Documentation about the ReScript build system and its toolchain"
 canonical: "/docs/manual/v12.0.0/build-overview"
+section: "Build System"
+order: 1
 ---
 
 # Build System Overview

--- a/pages/docs/manual/v12.0.0/build-performance.mdx
+++ b/pages/docs/manual/v12.0.0/build-performance.mdx
@@ -3,6 +3,8 @@ title: "Performance"
 metaTitle: "Build Performance"
 description: "ReScript build performance and measuring tools"
 canonical: "/docs/manual/v12.0.0/build-performance"
+section: "Build System"
+order: 7
 ---
 
 # Build Performance

--- a/pages/docs/manual/v12.0.0/build-pinned-dependencies.mdx
+++ b/pages/docs/manual/v12.0.0/build-pinned-dependencies.mdx
@@ -3,6 +3,8 @@ title: "Pinned Dependencies"
 metaTitle: "Pinned Dependencies"
 description: "Handling multiple packages within one ReScript project with pinned dependencies"
 canonical: "/docs/manual/v12.0.0/build-pinned-dependencies"
+section: "Build System"
+order: 5
 ---
 
 # Pinned Dependencies

--- a/pages/docs/manual/v12.0.0/control-flow.mdx
+++ b/pages/docs/manual/v12.0.0/control-flow.mdx
@@ -2,6 +2,8 @@
 title: "If-Else & Loops"
 description: "If, else, ternary, for, and while"
 canonical: "/docs/manual/v12.0.0/control-flow"
+section: "Language Features"
+order: 14
 ---
 
 # If-Else & Loops

--- a/pages/docs/manual/v12.0.0/converting-from-js.mdx
+++ b/pages/docs/manual/v12.0.0/converting-from-js.mdx
@@ -2,6 +2,8 @@
 title: "Converting from JS"
 description: "How to convert to ReScript with an existing JS codebase"
 canonical: "/docs/manual/v12.0.0/converting-from-js"
+section: "Guides"
+order: 1
 ---
 
 # Converting from JS

--- a/pages/docs/manual/v12.0.0/dict.mdx
+++ b/pages/docs/manual/v12.0.0/dict.mdx
@@ -2,6 +2,8 @@
 title: "Dictionary"
 description: "Dictionary data structure in ReScript"
 canonical: "/docs/manual/v12.0.0/dict"
+section: "Language Features"
+order: 8
 ---
 
 # Dictionary

--- a/pages/docs/manual/v12.0.0/editor-code-analysis.mdx
+++ b/pages/docs/manual/v12.0.0/editor-code-analysis.mdx
@@ -3,6 +3,8 @@ title: "Dead Code Analysis in ReScript"
 metaTitle: "Dead Code Analysis in ReScript"
 description: "Documentation about ReScript editor plugins and code analysis"
 canonical: "/docs/manual/v12.0.0/editor-plugins"
+section: "Guides"
+order: 2
 ---
 
 # Dead Code Analysis in ReScript

--- a/pages/docs/manual/v12.0.0/editor-plugins.mdx
+++ b/pages/docs/manual/v12.0.0/editor-plugins.mdx
@@ -3,6 +3,8 @@ title: "Editor"
 metaTitle: "Editor"
 description: "Documentation about ReScript editor plugins and code analysis"
 canonical: "/docs/manual/v12.0.0/editor-plugins"
+section: "Overview"
+order: 3
 ---
 
 # Editor

--- a/pages/docs/manual/v12.0.0/embed-raw-javascript.mdx
+++ b/pages/docs/manual/v12.0.0/embed-raw-javascript.mdx
@@ -2,6 +2,8 @@
 title: "Embed Raw JavaScript"
 description: "Utility syntax to for raw JS usage in ReScript"
 canonical: "/docs/manual/v12.0.0/embed-raw-javascript"
+section: "JavaScript Interop"
+order: 2
 ---
 
 # Embed Raw JavaScript

--- a/pages/docs/manual/v12.0.0/equality-comparison.mdx
+++ b/pages/docs/manual/v12.0.0/equality-comparison.mdx
@@ -2,6 +2,8 @@
 title: "Equality and Comparison"
 description: "Handling equality and comparison checks"
 canonical: "/docs/manual/v12.0.0/equality-comparison"
+section: "Language Features"
+order: 28
 ---
 
 # Equality and Comparison

--- a/pages/docs/manual/v12.0.0/exception.mdx
+++ b/pages/docs/manual/v12.0.0/exception.mdx
@@ -2,6 +2,8 @@
 title: "Exception"
 description: "Exceptions and exception handling in ReScript"
 canonical: "/docs/manual/v12.0.0/exception"
+section: "Language Features"
+order: 19
 ---
 
 # Exception

--- a/pages/docs/manual/v12.0.0/extensible-variant.mdx
+++ b/pages/docs/manual/v12.0.0/extensible-variant.mdx
@@ -2,6 +2,8 @@
 title: "Extensible Variant"
 description: "Extensible Variants in ReScript"
 canonical: "/docs/manual/v12.0.0/extensible-variant"
+section: "Advanced Features"
+order: 1
 ---
 
 # Extensible Variant

--- a/pages/docs/manual/v12.0.0/external.mdx
+++ b/pages/docs/manual/v12.0.0/external.mdx
@@ -2,6 +2,8 @@
 title: "External (Bind to Any JS Library)"
 description: "The external keyword"
 canonical: "/docs/manual/v12.0.0/external"
+section: "JavaScript Interop"
+order: 3
 ---
 
 # External (Bind to Any JS Library)

--- a/pages/docs/manual/v12.0.0/function.mdx
+++ b/pages/docs/manual/v12.0.0/function.mdx
@@ -2,6 +2,8 @@
 title: "Function"
 description: "Function syntax in ReScript"
 canonical: "/docs/manual/v12.0.0/function"
+section: "Language Features"
+order: 13
 ---
 
 # Function

--- a/pages/docs/manual/v12.0.0/generalized-algebraic-data-types.mdx
+++ b/pages/docs/manual/v12.0.0/generalized-algebraic-data-types.mdx
@@ -2,6 +2,8 @@
 title: "Generalized Algebraic Data Types"
 description: "Generalized Algebraic Data Types in ReScript"
 canonical: "/docs/manual/v12.0.0/generalized-algebraic-data-types"
+section: "Advanced Features"
+order: 4
 ---
 
 # Generalized Algebraic Data Types

--- a/pages/docs/manual/v12.0.0/generate-converters-accessors.mdx
+++ b/pages/docs/manual/v12.0.0/generate-converters-accessors.mdx
@@ -2,6 +2,8 @@
 title: "Generate Converters & Helpers"
 description: "All about the @deriving decorator, and how to generate code from types"
 canonical: "/docs/manual/v12.0.0/generate-converters-accessors"
+section: "JavaScript Interop"
+order: 12
 ---
 
 # Generate Converters & Helpers

--- a/pages/docs/manual/v12.0.0/import-export.mdx
+++ b/pages/docs/manual/v12.0.0/import-export.mdx
@@ -2,6 +2,8 @@
 title: "Import & Export"
 description: "Importing / exporting in ReScript modules"
 canonical: "/docs/manual/v12.0.0/import-export"
+section: "Language Features"
+order: 25
 ---
 
 # Import & Export

--- a/pages/docs/manual/v12.0.0/import-from-export-to-js.mdx
+++ b/pages/docs/manual/v12.0.0/import-from-export-to-js.mdx
@@ -2,6 +2,8 @@
 title: "Import from / Export to JS"
 description: "Importing / exporting JS module content in ReScript"
 canonical: "/docs/manual/v12.0.0/import-from-export-to-js"
+section: "JavaScript Interop"
+order: 7
 ---
 
 # Import from/Export to JS

--- a/pages/docs/manual/v12.0.0/inlining-constants.mdx
+++ b/pages/docs/manual/v12.0.0/inlining-constants.mdx
@@ -2,6 +2,8 @@
 title: "Inlining Constants"
 description: "Inlining constants"
 canonical: "/docs/manual/v12.0.0/inlining-constants"
+section: "JavaScript Interop"
+order: 10
 ---
 
 # Inlining Constants

--- a/pages/docs/manual/v12.0.0/installation.mdx
+++ b/pages/docs/manual/v12.0.0/installation.mdx
@@ -2,6 +2,8 @@
 title: "Installation"
 description: "ReScript installation and setup instructions"
 canonical: "/docs/manual/v12.0.0/installation"
+section: "Overview"
+order: 2
 ---
 
 # Installation

--- a/pages/docs/manual/v12.0.0/interop-cheatsheet.mdx
+++ b/pages/docs/manual/v12.0.0/interop-cheatsheet.mdx
@@ -2,6 +2,8 @@
 title: "Interop Cheatsheet"
 description: "Cheatsheet for various interop scenarios in ReScript"
 canonical: "/docs/manual/v12.0.0/interop-cheatsheet"
+section: "JavaScript Interop"
+order: 1
 ---
 
 # Interop Cheatsheet

--- a/pages/docs/manual/v12.0.0/interop-with-js-build-systems.mdx
+++ b/pages/docs/manual/v12.0.0/interop-with-js-build-systems.mdx
@@ -2,6 +2,8 @@
 title: "Interop with JS Build Systems"
 description: "Documentation on how to interact with existing JS build systems"
 canonical: "/docs/manual/v12.0.0/interop-with-js-build-systems"
+section: "Build System"
+order: 6
 ---
 
 # Interop with JS Build Systems

--- a/pages/docs/manual/v12.0.0/introduction.mdx
+++ b/pages/docs/manual/v12.0.0/introduction.mdx
@@ -2,6 +2,8 @@
 title: "Introduction"
 description: "Introduction to the ReScript programming language"
 canonical: "/docs/manual/v12.0.0/introduction"
+section: "Overview"
+order: 1
 ---
 
 # ReScript

--- a/pages/docs/manual/v12.0.0/json.mdx
+++ b/pages/docs/manual/v12.0.0/json.mdx
@@ -2,6 +2,8 @@
 title: "JSON"
 description: "Interacting with JSON in ReScript"
 canonical: "/docs/manual/v12.0.0/json"
+section: "JavaScript Interop"
+order: 9
 ---
 
 # JSON

--- a/pages/docs/manual/v12.0.0/jsx.mdx
+++ b/pages/docs/manual/v12.0.0/jsx.mdx
@@ -2,6 +2,8 @@
 title: "JSX"
 description: "JSX syntax in ReScript and React"
 canonical: "/docs/manual/v12.0.0/jsx"
+section: "Language Features"
+order: 18
 ---
 
 # JSX

--- a/pages/docs/manual/v12.0.0/lazy-values.mdx
+++ b/pages/docs/manual/v12.0.0/lazy-values.mdx
@@ -2,6 +2,8 @@
 title: "Lazy Value"
 description: "Data type for deferred computation in ReScript"
 canonical: "/docs/manual/v12.0.0/lazy-values"
+section: "Language Features"
+order: 20
 ---
 
 # Lazy Value

--- a/pages/docs/manual/v12.0.0/let-binding.mdx
+++ b/pages/docs/manual/v12.0.0/let-binding.mdx
@@ -2,6 +2,8 @@
 title: "Let Binding"
 description: "Let binding syntax for binding to values in ReScript"
 canonical: "/docs/manual/v12.0.0/let-binding"
+section: "Language Features"
+order: 2
 ---
 
 # Let Binding

--- a/pages/docs/manual/v12.0.0/libraries.mdx
+++ b/pages/docs/manual/v12.0.0/libraries.mdx
@@ -2,6 +2,8 @@
 title: "Libraries & Publishing"
 description: "Install & publish ReScript packages"
 canonical: "/docs/manual/v12.0.0/libraries"
+section: "JavaScript Interop"
+order: 14
 ---
 
 # Libraries & Publishing

--- a/pages/docs/manual/v12.0.0/module-functions.mdx
+++ b/pages/docs/manual/v12.0.0/module-functions.mdx
@@ -2,6 +2,8 @@
 title: "Module Functions"
 description: "Module Functions in ReScript"
 canonical: "/docs/manual/v12.0.0/module-functions"
+section: "Advanced Features"
+order: 3
 ---
 
 # Module Functions

--- a/pages/docs/manual/v12.0.0/module.mdx
+++ b/pages/docs/manual/v12.0.0/module.mdx
@@ -2,6 +2,8 @@
 title: "Module"
 description: "ReScript modules, module signatures and interface files"
 canonical: "/docs/manual/v12.0.0/module"
+section: "Language Features"
+order: 24
 ---
 
 # Module

--- a/pages/docs/manual/v12.0.0/mutation.mdx
+++ b/pages/docs/manual/v12.0.0/mutation.mdx
@@ -2,6 +2,8 @@
 title: "Mutation"
 description: "Imperative and mutative programming capabilities in ReScript"
 canonical: "/docs/manual/v12.0.0/mutation"
+section: "Language Features"
+order: 17
 ---
 
 # Mutation

--- a/pages/docs/manual/v12.0.0/null-undefined-option.mdx
+++ b/pages/docs/manual/v12.0.0/null-undefined-option.mdx
@@ -2,6 +2,8 @@
 title: "Null, Undefined and Option"
 description: "JS interop with nullable and optional values in ReScript"
 canonical: "/docs/manual/v12.0.0/null-undefined-option"
+section: "Language Features"
+order: 11
 ---
 
 # Null, Undefined and Option

--- a/pages/docs/manual/v12.0.0/object.mdx
+++ b/pages/docs/manual/v12.0.0/object.mdx
@@ -2,6 +2,8 @@
 title: "Object"
 description: "Interoping with JS objects in ReScript"
 canonical: "/docs/manual/v12.0.0/object"
+section: "Language Features"
+order: 7
 ---
 
 # Object

--- a/pages/docs/manual/v12.0.0/overview.mdx
+++ b/pages/docs/manual/v12.0.0/overview.mdx
@@ -3,6 +3,8 @@ title: "Overview"
 metaTitle: "Language Features Overview"
 description: "A quick overview on ReScript's syntax"
 canonical: "/docs/manual/v12.0.0/overview"
+section: "Language Features"
+order: 1
 ---
 
 # Overview

--- a/pages/docs/manual/v12.0.0/pattern-matching-destructuring.mdx
+++ b/pages/docs/manual/v12.0.0/pattern-matching-destructuring.mdx
@@ -2,6 +2,8 @@
 title: "Pattern Matching / Destructuring"
 description: "Pattern matching and destructuring complex data structures in ReScript"
 canonical: "/docs/manual/v12.0.0/pattern-matching-destructuring"
+section: "Language Features"
+order: 16
 ---
 
 # Pattern Matching / Destructuring

--- a/pages/docs/manual/v12.0.0/pipe.mdx
+++ b/pages/docs/manual/v12.0.0/pipe.mdx
@@ -2,6 +2,8 @@
 title: "Pipe"
 description: "The Pipe operator (->)"
 canonical: "/docs/manual/v12.0.0/pipe"
+section: "Language Features"
+order: 15
 ---
 
 # Pipe

--- a/pages/docs/manual/v12.0.0/polymorphic-variant.mdx
+++ b/pages/docs/manual/v12.0.0/polymorphic-variant.mdx
@@ -2,6 +2,8 @@
 title: "Polymorphic Variant"
 description: "The Polymorphic Variant data structure in ReScript"
 canonical: "/docs/manual/v12.0.0/polymorphic-variant"
+section: "Language Features"
+order: 10
 ---
 
 # Polymorphic Variant

--- a/pages/docs/manual/v12.0.0/primitive-types.mdx
+++ b/pages/docs/manual/v12.0.0/primitive-types.mdx
@@ -2,6 +2,8 @@
 title: "Primitive Types"
 description: "Primitive Data Types in ReScript"
 canonical: "/docs/manual/v12.0.0/primitive-types"
+section: "Language Features"
+order: 4
 ---
 
 # Primitive Types

--- a/pages/docs/manual/v12.0.0/project-structure.mdx
+++ b/pages/docs/manual/v12.0.0/project-structure.mdx
@@ -2,6 +2,8 @@
 title: "Project Structure"
 description: "Notes on project structure and other rough ReScript guidelines"
 canonical: "/docs/manual/v12.0.0/project-structure"
+section: "Guides"
+order: 3
 ---
 
 # Project Structure

--- a/pages/docs/manual/v12.0.0/promise.mdx
+++ b/pages/docs/manual/v12.0.0/promise.mdx
@@ -2,6 +2,8 @@
 title: "Promises"
 description: "JS Promise handling in ReScript"
 canonical: "/docs/manual/v12.0.0/promise"
+section: "Language Features"
+order: 21
 ---
 
 # Promise

--- a/pages/docs/manual/v12.0.0/record.mdx
+++ b/pages/docs/manual/v12.0.0/record.mdx
@@ -2,6 +2,8 @@
 title: "Record"
 description: "Record types in ReScript"
 canonical: "/docs/manual/v12.0.0/record"
+section: "Language Features"
+order: 6
 ---
 
 # Record

--- a/pages/docs/manual/v12.0.0/reserved-keywords.mdx
+++ b/pages/docs/manual/v12.0.0/reserved-keywords.mdx
@@ -2,6 +2,8 @@
 title: "Reserved Keywords"
 description: "All reserved keywords in ReScript"
 canonical: "/docs/manual/v12.0.0/reserved-keywords"
+section: "Language Features"
+order: 27
 ---
 
 # Reserved Keywords

--- a/pages/docs/manual/v12.0.0/scoped-polymorphic-types.mdx
+++ b/pages/docs/manual/v12.0.0/scoped-polymorphic-types.mdx
@@ -2,6 +2,8 @@
 title: "Scoped Polymorphic Types"
 description: "Scoped Polymorphic Types in ReScript"
 canonical: "/docs/manual/v12.0.0/scoped-polymorphic-types"
+section: "Advanced Features"
+order: 2
 ---
 
 # Scoped Polymorphic Types

--- a/pages/docs/manual/v12.0.0/shared-data-types.mdx
+++ b/pages/docs/manual/v12.0.0/shared-data-types.mdx
@@ -2,6 +2,8 @@
 title: "Shared Data Types"
 description: "Data types that share runtime presentation between JS and ReScript"
 canonical: "/docs/manual/v12.0.0/shared-data-types"
+section: "JavaScript Interop"
+order: 2
 ---
 
 # Shared Data Types

--- a/pages/docs/manual/v12.0.0/tagged-templates.mdx
+++ b/pages/docs/manual/v12.0.0/tagged-templates.mdx
@@ -2,6 +2,8 @@
 title: "Tagged templates"
 description: "Using tagged templates in ReScript"
 canonical: "/docs/manual/v12.0.0/tagged-templates"
+section: "Language Features"
+order: 23
 ---
 
 # Tagged templates

--- a/pages/docs/manual/v12.0.0/tuple.mdx
+++ b/pages/docs/manual/v12.0.0/tuple.mdx
@@ -2,6 +2,8 @@
 title: "Tuple"
 description: "Tuple types and values in ReScript"
 canonical: "/docs/manual/v12.0.0/tuple"
+section: "Language Features"
+order: 5
 ---
 
 # Tuple

--- a/pages/docs/manual/v12.0.0/type.mdx
+++ b/pages/docs/manual/v12.0.0/type.mdx
@@ -2,6 +2,8 @@
 title: "Type"
 description: "Types and type definitions in ReScript"
 canonical: "/docs/manual/v12.0.0/type"
+section: "Language Features"
+order: 3
 ---
 
 # Type

--- a/pages/docs/manual/v12.0.0/typescript-integration.mdx
+++ b/pages/docs/manual/v12.0.0/typescript-integration.mdx
@@ -2,6 +2,8 @@
 title: "TypeScript"
 description: "GenType - Interoperability between ReScript and TypeScript"
 canonical: "/docs/manual/v12.0.0/typescript-integration"
+section: "JavaScript Interop"
+order: 15
 ---
 
 # ReScript & TypeScript

--- a/pages/docs/manual/v12.0.0/use-illegal-identifier-names.mdx
+++ b/pages/docs/manual/v12.0.0/use-illegal-identifier-names.mdx
@@ -2,6 +2,8 @@
 title: "Use Illegal Identifier Names"
 description: "Handling (JS) naming collisions in ReScript"
 canonical: "/docs/manual/v12.0.0/use-illegal-identifier-names"
+section: "JavaScript Interop"
+order: 11
 ---
 
 # Use Illegal Identifier Names

--- a/pages/docs/manual/v12.0.0/variant.mdx
+++ b/pages/docs/manual/v12.0.0/variant.mdx
@@ -2,6 +2,8 @@
 title: "Variant"
 description: "Variant data structures in ReScript"
 canonical: "/docs/manual/v12.0.0/variant"
+section: "Language Features"
+order: 9
 ---
 
 # Variant

--- a/pages/docs/manual/v12.0.0/warning-numbers.mdx
+++ b/pages/docs/manual/v12.0.0/warning-numbers.mdx
@@ -2,6 +2,8 @@
 title: "Warning Numbers"
 description: "Available compiler warning numbers in ReScript"
 canonical: "/docs/manual/v12.0.0/warning-numbers"
+section: "Build System"
+order: 8
 ---
 
 import { make as WarningTable } from "src/components/WarningTable.mjs";

--- a/public/llms/manual/template.mdx
+++ b/public/llms/manual/template.mdx
@@ -2,6 +2,8 @@
 title: "LLMs"
 description: "Documentation for LLMs"
 canonical: "/docs/manual/<VERSION>/llms"
+section: "Overview"
+order: 4
 ---
 
 # Documentation for LLMs


### PR DESCRIPTION
This is in preparation for the migration to React Router.

This doesn't do anything yet, but frontmatter will be the primary way to add details and organize markdown files instead of the build scripts and config files we use today.